### PR TITLE
Turn off EAP capability for RTC workflow

### DIFF
--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -432,14 +432,14 @@ def compare_rtc_hdf5_files(file_1, file_2):
         # Print out the dataset / attribute structure discrepancy if there are any
         if not flag_identical_dataset_structure:
             print('    \n\033[91mFAILED\033[00m: Dataset structure not identical.')
-            print('    In the 1st HDF5, not in the 2nd data:')
+            print('In the 1st HDF5, not in the 2nd data:')
             list_dataset_1st_only = list(set_dataset_1 - set_dataset_2)
             list_dataset_1st_only.sort()
             list_dataset_2nd_only = list(set_dataset_2 - set_dataset_1)
             list_dataset_2nd_only.sort()
-            print('\n    '.join(list_dataset_1st_only))
-            print('    In the 2st HDF5, not in the 1nd data:')
-            print('\n    '.join(list_dataset_2nd_only))
+            print('\n    '+'\n    '.join(list_dataset_1st_only))
+            print('\nIn the 2st HDF5, not in the 1nd data:')
+            print('\n    '+'\n    '.join(list_dataset_2nd_only))
 
         if not flag_identical_attrs_structure:
             print('    \n\033[91mFAILED\033[00m: '
@@ -448,10 +448,16 @@ def compare_rtc_hdf5_files(file_1, file_2):
             list_attrs_1st_only.sort()
             list_attrs_2nd_only = list(set_attrs_2 - set_attrs_1)
             list_attrs_2nd_only.sort()
-            print('    In the 1st HDF5, not in the 2nd data:')
-            print('\n    '.join(list_attrs_1st_only))
-            print('    In the 2nd HDF5, not in the 1st data:')
-            print('\n    '.join(list_attrs_2nd_only))
+
+            print('In the 1st HDF5, not in the 2nd data:')
+            print('\r    ' +
+                  '\r    '.join(list_attrs_1st_only).\
+                  replace('\n', ',\tkey = ').replace('\r', '\n'))
+
+            print('\nIn the 2nd HDF5, not in the 1st data:')
+            print('\r    ' +
+                  '\r    '.join(list_attrs_2nd_only).\
+                  replace('\n', ',\tkey = ').replace('\r', '\n'))
 
         # Print the test summary
         print('\nTest summary:')
@@ -463,7 +469,7 @@ def compare_rtc_hdf5_files(file_1, file_2):
             print( '    \033[91mFAILED\033[00m: '
                   f'{len(list_dataset_1st_only)} datasets from the 1st HDF are'
                    ' not found in the 2nd file.\n'
-                  f'        {len(list_dataset_2nd_only)} datasets from the 2nd HDF are'
+                  f'            {len(list_dataset_2nd_only)} datasets from the 2nd HDF are'
                    ' not found in the 1st file.')
 
         # Attributes structure
@@ -473,7 +479,7 @@ def compare_rtc_hdf5_files(file_1, file_2):
             print( '    \033[91mFAILED\033[00m: '
                   f'{len(list_attrs_1st_only)} attributes from the 1st HDF are'
                    ' not found in the 2nd file.\n'
-                  f'        {len(list_attrs_2nd_only)} attributes from the 2nd HDF are'
+                  f'            {len(list_attrs_2nd_only)} attributes from the 2nd HDF are'
                    ' not found in the 1st file.')
 
         # Closeness of the common dataset

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -166,6 +166,40 @@ def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
         val_1 = np.array(hdf5_obj_1[str_key])
         val_2 = np.array(hdf5_obj_2[str_key])
 
+    # convert oeject reference to the path to which it is pointing
+    if (len(val_1.shape)>=1) and ('shape' in dir(val_1[0])):
+        if isinstance(val_1[0], np.void) or\
+        ((len(val_1[0].shape) == 1) and (isinstance(val_1[0][0], h5py.h5r.Reference))):
+            # Example:
+            # attribute `REFERENCE_LIST` in
+            # /science/CSAR/RTC/grids/frequencyA/xCoordinates'
+            # attribute `DIMENSION_LIST` in
+            # /science/CSAR/RTC/grids/frequencyA/VH
+            list_val_1 = list(itertools.chain.from_iterable(val_1))
+            val_1_new = [None] * len(list_val_1)
+            for i_val, element_1 in enumerate(list_val_1):
+                if isinstance(element_1, h5py.h5r.Reference):
+                    print('    - Object reference found.')
+                    val_1_new[i_val] = np.str_(hdf5_obj_1[element_1].name)
+                else:
+                    val_1_new[i_val] = element_1
+            val_1 = np.array(val_1_new)
+
+    #Repeat the same thing for val_2
+    if (len(val_2.shape)>=1) and ('shape' in dir(val_2[0])):
+        if isinstance(val_2[0], np.void) or\
+        ((len(val_2[0].shape) == 1) and (isinstance(val_2[0][0], h5py.h5r.Reference))):
+            list_val_2 = list(itertools.chain.from_iterable(val_2))
+            val_2_new = [None] * len(list_val_2)
+            for i_val, element_2 in enumerate(list_val_2):
+                if isinstance(element_2, h5py.h5r.Reference):
+                    print('    - Object reference found.')
+                    val_2_new[i_val] = np.str_(hdf5_obj_2[element_2].name)
+                else:
+                    val_2_new[i_val] = element_2
+            val_2 = np.array(val_2_new)
+
+
     shape_val_1 = val_1.shape
     shape_val_2 = val_2.shape
 
@@ -196,41 +230,6 @@ def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
 
     if len(shape_val_1) == 1:
         # 1d vector
-
-        # Dereference if val_1 and val_2 have HDF5 objstc reference.
-        # Convert the 1d numpy array into list to differentiate the comparison process
-        if 'shape' in dir(val_1[0]):
-            if isinstance(val_1[0], np.void) or\
-            ((len(val_1[0].shape) == 1) and (isinstance(val_1[0][0], h5py.h5r.Reference))):
-                # Example:
-                # attribute `REFERENCE_LIST` in
-                # /science/CSAR/RTC/grids/frequencyA/xCoordinates'
-                # attribute `DIMENSION_LIST` in
-                # /science/CSAR/RTC/grids/frequencyA/VH
-                list_val_1 = list(itertools.chain.from_iterable(val_1))
-                val_1_new = [None] * len(list_val_1)
-                for i_val, element_1 in enumerate(list_val_1):
-                    if isinstance(element_1, h5py.h5r.Reference):
-                        print('    - Object reference found.')
-                        val_1_new[i_val] = np.str_(hdf5_obj_1[element_1].name)
-                    else:
-                        val_1_new[i_val] = element_1
-                val_1 = np.array(val_1_new)
-
-        # Repeat the same process for `val_2`
-        if 'shape' in dir(val_2[0]):
-            if isinstance(val_2[0], np.void) or\
-            ((len(val_2[0].shape) == 1) and (isinstance(val_2[0][0], h5py.h5r.Reference))):
-
-                list_val_2 = list(itertools.chain.from_iterable(val_2))
-                val_2_new = [None] * len(list_val_2)
-                for i_val, element_2 in enumerate(list_val_2):
-                    if isinstance(element_2, h5py.h5r.Reference):
-                        print('    - Object reference found.')
-                        val_2_new[i_val] = np.str_(hdf5_obj_2[element_2].name)
-                    else:
-                        val_2_new[i_val] = element_2
-                val_2 = np.array(val_2_new)
 
         if issubclass(val_1.dtype.type, np.number) and issubclass(val_2.dtype.type, np.number):
             # val_1 and val_2 are numeric numpy array

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -349,12 +349,10 @@ def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False,
             print_data_difference(val_1, val_2)
         return return_val
 
-    # Unnexpected dataset shape
-    print('    - Detected an issue on the dataset shapes: ',
-            f'Dataset key: {str_key}, '
-            'dataset shape in the 1st HDF5: ', shape_val_1,
-            'dataset shape in the 2nd HDF5: ', shape_val_2)
-    return False
+    # Unexpected failure to compare `val_1` and `val_2`
+    raise ValueError(f'Failed to compare the element: {str_message_data_location}'
+                     f'dataset shape in the 1st HDF5: {shape_val_1}'
+                     f'dataset shape in the 2nd HDF5: {shape_val_2}')
 
 
 def compare_rtc_hdf5_files(file_1, file_2):

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -130,6 +130,9 @@ def compare_dataset_attr(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
 
     elif len(shape_val_1)==1 and len(shape_val_2)==1:
         # 1d vector
+        # NOTE: When the original val_1 has object reference,
+        # the original val_1 will be converted to `list``, rather than `np.ndarray`
+
         if 'shape' in dir(val_1[0]):
             if isinstance(val_1[0], np.void):
                 list_val_1 = list(itertools.chain.from_iterable(val_1))
@@ -194,7 +197,7 @@ def compare_dataset_attr(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
                 # List shape does not match
                 return False
 
-        elif (val_1.dtype == 'float') and (val_2.dtype == 'float'):
+        elif issubclass(val_1.dtype.type,np.number) and issubclass(val_2.dtype.type,np.number):
             return np.array_equal(val_1, val_2, equal_nan=True)
         else:
             return np.array_equal(val_1, val_2)

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -113,7 +113,7 @@ def get_list_dataset_attrs_keys(hdf_obj_1: h5py.Group,
     return list_dataset_so_far, list_attrs_so_far
 
 
-def compare_dataset_attr(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
+def compare_hdf5_element(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
     '''
     Compare the dataset or attribute defined by `str_key`
     NOTE: For attributes, the path and the key are separated by newline character ('\n')
@@ -333,7 +333,7 @@ def main():
             print(f'Testing : {id_flag+1:03d} / {len(union_set_dataset):03d},'
                   f' key: {key_dataset} ')
 
-            list_flag_identical_dataset[id_flag] = compare_dataset_attr(hdf5_in_1,
+            list_flag_identical_dataset[id_flag] = compare_hdf5_element(hdf5_in_1,
                                                                         hdf5_in_2,
                                                                         key_dataset,
                                                                         is_attr=False)
@@ -367,7 +367,7 @@ def main():
             print(f'Testing : {id_flag+1:03d} / {len(union_set_attrs):03d}, '
                   f'path - key: {str_printout}')
 
-            list_flag_identical_attrs[id_flag] = compare_dataset_attr(hdf5_in_1,
+            list_flag_identical_attrs[id_flag] = compare_hdf5_element(hdf5_in_1,
                                                                       hdf5_in_2,
                                                                       key_attr,
                                                                       is_attr=True)

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -255,7 +255,7 @@ def main():
 
         list_flag_identical_dataset = [None] * len(union_set_dataset)
         for id_flag, key_dataset in enumerate(union_set_dataset):
-            list_flag_identical_dataset[id_flag] = comapre_dataset_attr(hdf5_in_1,
+            list_flag_identical_dataset[id_flag] = compare_dataset_attr(hdf5_in_1,
                                                                         hdf5_in_2,
                                                                         key_dataset,
                                                                         is_attr=False)
@@ -287,7 +287,7 @@ def main():
 
         list_flag_identical_attrs = [None] * len(union_set_attrs)
         for id_flag, key_attr in enumerate(union_set_attrs):
-            list_flag_identical_attrs[id_flag] = comapre_dataset_attr(hdf5_in_1,
+            list_flag_identical_attrs[id_flag] = compare_dataset_attr(hdf5_in_1,
                                                                       hdf5_in_2,
                                                                       key_attr,
                                                                       is_attr=True)

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -55,8 +55,6 @@ def print_data_difference(val_1, val_2, indent=4):
               f'[{index_first_discrepancy}] : '
               f'1st=({val_1[index_first_discrepancy]}), 2nd=({val_2[index_first_discrepancy]})')
 
-
-
     # Check pixel-by-pixel nan / non-nan difference
     if (issubclass(val_1.dtype.type, np.floating) and issubclass(val_2.dtype.type, np.floating)) or\
     (issubclass(val_1.dtype.type, np.complexfloating) and issubclass(val_2.dtype.type, np.complexfloating)):
@@ -70,8 +68,21 @@ def print_data_difference(val_1, val_2, indent=4):
             num_pixel_nan_discrepancy = mask_nan_discrepancy.sum()
             index_pixel_nan_discrepancy = np.where(mask_nan_discrepancy)
             print(f'{str_indent} Found {num_pixel_nan_discrepancy} '
-                   'inconsistent values between input arrays. '
+                   'NaN inconsistecy between the input arrays. '
                   f'First index of the discrepancy: [{index_pixel_nan_discrepancy[0][0]}]')
+
+            print(f'{str_indent} val_1[{index_pixel_nan_discrepancy[0][0]}] = '
+                  f'{val_1[index_pixel_nan_discrepancy[0][0]]}')
+            print(f'{str_indent} val_2[{index_pixel_nan_discrepancy[0][0]}] = '
+                  f'{val_2[index_pixel_nan_discrepancy[0][0]]}')
+
+            # Operations to print out further info regarding the discrapancy
+            num_nan_both = np.logical_and(mask_nan_val_1, mask_nan_val_2).sum()
+            num_nan_val_1 = np.sum(mask_nan_val_1)
+            num_nan_val_2 = np.sum(mask_nan_val_2)
+            print(f'{indent} # NaNs on val_1 only: {num_nan_val_1 - num_nan_both}')
+            print(f'{indent} # NaNs on val_2 only: {num_nan_val_2 - num_nan_both}')
+
 
 def get_list_dataset_attrs_keys(hdf_obj_1: h5py.Group,
                                 key_in: str='/',
@@ -167,14 +178,14 @@ def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
         val_2 = np.array(hdf5_obj_2[str_key])
 
     # convert oeject reference to the path to which it is pointing
+    # Example:
+    # attribute `REFERENCE_LIST` in
+    # /science/CSAR/RTC/grids/frequencyA/xCoordinates'
+    # attribute `DIMENSION_LIST` in
+    # /science/CSAR/RTC/grids/frequencyA/VH
     if (len(val_1.shape)>=1) and ('shape' in dir(val_1[0])):
         if isinstance(val_1[0], np.void) or\
         ((len(val_1[0].shape) == 1) and (isinstance(val_1[0][0], h5py.h5r.Reference))):
-            # Example:
-            # attribute `REFERENCE_LIST` in
-            # /science/CSAR/RTC/grids/frequencyA/xCoordinates'
-            # attribute `DIMENSION_LIST` in
-            # /science/CSAR/RTC/grids/frequencyA/VH
             list_val_1 = list(itertools.chain.from_iterable(val_1))
             val_1_new = [None] * len(list_val_1)
             for i_val, element_1 in enumerate(list_val_1):
@@ -198,7 +209,6 @@ def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
                 else:
                     val_2_new[i_val] = element_2
             val_2 = np.array(val_2_new)
-
 
     shape_val_1 = val_1.shape
     shape_val_2 = val_2.shape

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -38,14 +38,18 @@ def printout_data_difference(val_1, val_2, indent=4):
 
     str_indent = ' ' * indent + '-'
 
-    difference_val = val_1 - val_2
-    index_max_diff = np.nanargmax(np.abs(difference_val))
+    # printout the difference when the array is numeric
+    if issubclass(val_1.dtype.type, np.number) and issubclass(val_2.dtype.type, np.number):
+        difference_val = val_1 - val_2
+        index_max_diff = np.nanargmax(np.abs(difference_val))
 
-    print(f'{str_indent} Maximum difference of {difference_val[index_max_diff]} '
-          f'detected from index [{index_max_diff}]')
+        print(f'{str_indent} Maximum difference of {difference_val[index_max_diff]} '
+            f'detected from index [{index_max_diff}]')
 
     # Check pixel-by-pixel nan / non-nan difference
-    if issubclass(val_1.dtype.type, np.float_) and issubclass(val_2.dtype.type, np.float_):
+    if (issubclass(val_1.dtype.type, np.floating) and issubclass(val_2.dtype.type, np.floating)) or\
+    (issubclass(val_1.dtype.type, np.complexfloating) and issubclass(val_2.dtype.type, np.complexfloating)):
+
         mask_nan_val_1 = np.isnan(val_1)
         mask_nan_val_2 = np.isnan(val_2)
 

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -128,9 +128,12 @@ def compare_dataset_attr(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
 
     if len(shape_val_1)==0 and len(shape_val_2)==0:
         # Scalar value
-        print(f'    - 1st value:{val_1}')
-        print(f'    - 2nd value:{val_2}')
-        if issubclass(val_1.dtype.type, np.number) and issubclass(val_2.dtype.type, np.number):
+        print(f'    - 1st value: {val_1}')
+        print(f'    - 2nd value: {val_2}')
+
+        if issubclass(val_1.dtype.type, np.number) and\
+        issubclass(val_2.dtype.type, np.number):
+
             # numerical array
             return_val = np.array_equal(val_1, val_2, equal_nan=True)
             if not return_val:
@@ -160,8 +163,8 @@ def compare_dataset_attr(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
                 val_1_new = [None] * len(list_val_1)
                 for i_val, element_1 in enumerate(list_val_1):
                     if isinstance(element_1, h5py.h5r.Reference):
-                        print('    - Object reference found. Dereferencing.')
-                        val_1_new[i_val] = hdf5_obj_1[element_1]
+                        print('    - Object reference found.')
+                        val_1_new[i_val] = np.str_(hdf5_obj_1[element_1].name)
                     else:
                         val_1_new[i_val] = element_1
                 val_1 = val_1_new
@@ -175,8 +178,8 @@ def compare_dataset_attr(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
                 val_2_new = [None] * len(list_val_2)
                 for i_val, element_2 in enumerate(list_val_2):
                     if isinstance(element_2, h5py.h5r.Reference):
-                        print('    - Object reference found. Dereferencing.')
-                        val_2_new[i_val] = hdf5_obj_2[element_2]
+                        print('    - Object reference found.')
+                        val_2_new[i_val] = np.str_(hdf5_obj_2[element_2].name)
                     else:
                         val_2_new[i_val] = element_2
                 val_2 = val_2_new
@@ -195,12 +198,23 @@ def compare_dataset_attr(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
                           f'shape: {element_1.shape} vs. {element_2.shape}')
                     return False
 
-                if not np.allclose(element_1,
-                                   element_2,
-                                   RTC_S1_PRODUCTS_ERROR_TOLERANCE,
-                                   equal_nan=True):
-                    print('    - Same element shape but failed to pass np.allclose()')
-                    return False
+                if issubclass(element_1.dtype.type, np.number) and\
+                issubclass(element_2.dtype.type, np.number):
+
+                    return_val = not np.allclose(element_1,
+                                                 element_2,
+                                                 RTC_S1_PRODUCTS_ERROR_TOLERANCE,
+                                                 equal_nan=True)
+
+                return_val = np.array_equal(element_1,element_2)
+
+                if not return_val:
+                    print('    - Same element shape but '
+                          'failed to pass np.allclose() or np.array_equal()')
+                    print(f'    - 1st element: {element_1}')
+                    print(f'    - 2nd element: {element_2}')
+
+                return return_val
 
             # Went through all elements in the list,
             # and passed the closeness test in the for loop

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -134,10 +134,14 @@ def compare_dataset_attr(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
         # Dereference if val_1 and val_2 have HDF5 objstc reference.
         # Convert the 1d numpy array into list to differentiate the comparison process
         if 'shape' in dir(val_1[0]):
-        #if not np.isscalar(val_1[0]):
-            if isinstance(val_1[0], np.void):
-                # Example: attribute `REFERENCE_LIST` in
+            if isinstance(val_1[0], np.void) or\
+            ((len(val_1[0].shape) == 1) and (isinstance(val_1[0][0], h5py.h5r.Reference))):
+
+                # Example:
+                # attribute `REFERENCE_LIST` in
                 # /science/CSAR/RTC/grids/frequencyA/xCoordinates'
+                # attribute `DIMENSION_LIST` in
+                # /science/CSAR/RTC/grids/frequencyA/VH
                 list_val_1 = list(itertools.chain.from_iterable(val_1))
                 val_1_new = [None] * len(list_val_1)
                 for i_val, element_1 in enumerate(list_val_1):
@@ -147,33 +151,11 @@ def compare_dataset_attr(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
                         val_1_new[i_val] = element_1
                 val_1 = val_1_new
 
-            elif (len(val_1[0].shape) == 1) and (isinstance(val_1[0][0], h5py.h5r.Reference)):
-                # Example: attribute `DIMENSION_LIST` in
-                # /science/CSAR/RTC/grids/frequencyA/VH
-                list_val_1 = list(itertools.chain.from_iterable(val_1))
-                val_1_new=[None] * len(list_val_1)
-                for i_val, element_1 in enumerate(list_val_1):
-                    if isinstance(element_1, h5py.h5r.Reference):
-                        val_1_new[i_val] = hdf5_obj_1[element_1]
-                    else:
-                        val_1_new[i_val] = element_1
-                val_1 = val_1_new
-
         # Repeat the same process for `val_2`
         if 'shape' in dir(val_2[0]):
-        #if not np.isscalar(val_2[0]):
-            if isinstance(val_2[0], np.void):
-                list_val_2 = list(itertools.chain.from_iterable(val_2))
-                val_2_new = [None] * len(list_val_2)
-                for i_val, element_2 in enumerate(list_val_2):
-                    if isinstance(element_2, h5py.h5r.Reference):
-                        val_2_new[i_val] = hdf5_obj_2[element_2]
-                    else:
-                        val_2_new[i_val] = element_2
+            if isinstance(val_2[0], np.void) or\
+            ((len(val_2[0].shape) == 1) and (isinstance(val_2[0][0], h5py.h5r.Reference))):
 
-                val_2 = val_2_new
-
-            elif (len(val_2[0].shape) == 1) and (isinstance(val_2[0][0], h5py.h5r.Reference)):
                 list_val_2 = list(itertools.chain.from_iterable(val_2))
                 val_2_new = [None] * len(list_val_2)
                 for i_val, element_2 in enumerate(list_val_2):

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -135,7 +135,7 @@ def get_list_dataset_attrs_keys(hdf_obj_1: h5py.Group,
 
     '''
     Recursively traverse the datasets and attributes within the input HDF5 group.
-    Returns the list of keys for the dataset and the attributes.
+    Returns the list of keys for datasets and attributes.
 
     NOTE:
     In case of attributes, the path and the attribute keys are

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -98,26 +98,27 @@ def print_data_difference(val_1, val_2, indent=4):
 
         mask_nan_discrepancy = np.logical_xor(mask_nan_val_1, mask_nan_val_2)
 
-        if np.any(mask_nan_discrepancy):
-            num_pixel_nan_discrepancy = mask_nan_discrepancy.sum()
-            index_pixel_nan_discrepancy = np.where(mask_nan_discrepancy)
-            print(f'{str_indent} Found {num_pixel_nan_discrepancy} '
-                'NaN inconsistencies between input arrays. '
-                'First index of the discrepancy: '
-                f'[{index_pixel_nan_discrepancy[0][0]}]')
-            print(f'{str_indent} val_1[{index_pixel_nan_discrepancy[0][0]}] = '
-                f'{val_1[index_pixel_nan_discrepancy[0][0]]}')
-            print(f'{str_indent} val_2[{index_pixel_nan_discrepancy[0][0]}] = '
-                f'{val_2[index_pixel_nan_discrepancy[0][0]]}')
-
-            # Operations to print out further info regarding the discrapancy
-            num_nan_both = np.logical_and(mask_nan_val_1, mask_nan_val_2).sum()
-            num_nan_val_1 = np.sum(mask_nan_val_1)
-            num_nan_val_2 = np.sum(mask_nan_val_2)
-            print(f'{indent} # NaNs on val_1 only: {num_nan_val_1 - num_nan_both}')
-            print(f'{indent} # NaNs on val_2 only: {num_nan_val_2 - num_nan_both}')
-        else:
+        if not np.any(mask_nan_discrepancy):
             print(f'{str_indent} NaN discrepancy was not detected.')
+            return None
+
+        num_pixel_nan_discrepancy = mask_nan_discrepancy.sum()
+        index_pixel_nan_discrepancy = np.where(mask_nan_discrepancy)
+        print(f'{str_indent} Found {num_pixel_nan_discrepancy} '
+            'NaN inconsistencies between input arrays. '
+            'First index of the discrepancy: '
+            f'[{index_pixel_nan_discrepancy[0][0]}]')
+        print(f'{str_indent} val_1[{index_pixel_nan_discrepancy[0][0]}] = '
+            f'{val_1[index_pixel_nan_discrepancy[0][0]]}')
+        print(f'{str_indent} val_2[{index_pixel_nan_discrepancy[0][0]}] = '
+            f'{val_2[index_pixel_nan_discrepancy[0][0]]}')
+
+        # Operations to print out further info regarding the discrapancy
+        num_nan_both = np.logical_and(mask_nan_val_1, mask_nan_val_2).sum()
+        num_nan_val_1 = np.sum(mask_nan_val_1)
+        num_nan_val_2 = np.sum(mask_nan_val_2)
+        print(f'{str_indent} # NaNs on val_1 only: {num_nan_val_1 - num_nan_both}')
+        print(f'{str_indent} # NaNs on val_2 only: {num_nan_val_2 - num_nan_both}')
 
     # A line of space for better readability of the log
     print('')

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -179,8 +179,8 @@ def compare_hdf5_element(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
         print(f'    - 1st value: {val_1}')
         print(f'    - 2nd value: {val_2}')
 
-        if issubclass(val_1.dtype.type, np.number) and\
-        issubclass(val_2.dtype.type, np.number):
+        if (issubclass(val_1.dtype.type, np.number) and
+            issubclass(val_2.dtype.type, np.number)):
 
             # numerical array
             return_val = np.array_equal(val_1, val_2, equal_nan=True)

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -208,7 +208,7 @@ def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False,
     id_key: int
         total number of the list. Optional for printout purpose.
     print_passed_element: bool, default = True
-        turn on / off the printout for the p;assed test.
+        turn on / off the printout for the given test when it's successful.
 
 
     Return:

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -86,7 +86,8 @@ def print_data_difference(val_1, val_2, indent=4):
         index_first_discrepancy = np.where(flag_discrepancy)[0][0]
         print(f'{str_indent} The first discrepancy has detected from index '
               f'[{index_first_discrepancy}] : '
-              f'1st=({val_1[index_first_discrepancy]}), 2nd=({val_2[index_first_discrepancy]})')
+              f'1st=({val_1[index_first_discrepancy]}), '
+              f'2nd=({val_2[index_first_discrepancy]})')
 
     # Check pixel-by-pixel nan / non-nan difference
     if (issubclass(val_1.dtype.type, np.floating) or
@@ -105,7 +106,8 @@ def print_data_difference(val_1, val_2, indent=4):
         index_pixel_nan_discrepancy = np.where(mask_nan_discrepancy)
         print(f'{str_indent} Found {num_pixel_nan_discrepancy} of '
                 'NaN inconsistecy between the input arrays. '
-                f'First index of the discrepancy: [{index_pixel_nan_discrepancy[0][0]}]')
+                'First index of the discrepancy: '
+               f'[{index_pixel_nan_discrepancy[0][0]}]')
 
         print(f'{str_indent} val_1[{index_pixel_nan_discrepancy[0][0]}] = '
                 f'{val_1[index_pixel_nan_discrepancy[0][0]]}')
@@ -177,7 +179,8 @@ def get_list_dataset_attrs_keys(hdf_obj_1: h5py.Group,
 def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
     '''
     Compare the dataset or attribute defined by `str_key`
-    NOTE: For attributes, the path and the key are separated by newline character ('\n')
+    NOTE: For attributes, the path and the key are
+    separated by newline character ('\n')
 
     Parameters:
     -----------
@@ -201,7 +204,8 @@ def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
         path_attr, key_attr = str_key.split('\n')
         val_1 = hdf5_obj_1[path_attr].attrs[key_attr]
         val_2 = hdf5_obj_2[path_attr].attrs[key_attr]
-        # Force the datatype of val_1 and _2 to make use of numpy features
+
+        # Force the types of the values to np.ndarray to utulize numpy features
         if not isinstance(val_1,np.ndarray):
             val_1 = np.array(val_1)
 
@@ -224,7 +228,7 @@ def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
         ((len(val_1[0].shape) == 1) and (isinstance(val_1[0][0], h5py.h5r.Reference)))):
             val_1 = _unpack_array(val_1, hdf5_obj_1)
 
-    # Repeat the same thing for val_2
+    # Repeat the same process for val_2
     if (len(val_2.shape)>=1) and ('shape' in dir(val_2[0])):
         if (isinstance(val_2[0], np.void) or
         ((len(val_2[0].shape) == 1) and (isinstance(val_2[0][0], h5py.h5r.Reference)))):

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -67,7 +67,7 @@ def print_data_difference(val_1, val_2, indent=4):
         if np.any(mask_nan_discrepancy):
             num_pixel_nan_discrepancy = mask_nan_discrepancy.sum()
             index_pixel_nan_discrepancy = np.where(mask_nan_discrepancy)
-            print(f'{str_indent} Found {num_pixel_nan_discrepancy} '
+            print(f'{str_indent} Found {num_pixel_nan_discrepancy} of '
                    'NaN inconsistecy between the input arrays. '
                   f'First index of the discrepancy: [{index_pixel_nan_discrepancy[0][0]}]')
 

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -9,8 +9,7 @@ import itertools
 import h5py
 import numpy as np
 
-RTC_S1_PRODUCTS_ERROR_REL_TOLERANCE = 1e-05
-RTC_S1_PRODUCTS_ERROR_ABS_TOLERANCE = 1e-06
+RTC_S1_PRODUCTS_ERROR_TOLERANCE = 1e-6
 
 def _get_parser():
     parser = argparse.ArgumentParser(
@@ -279,8 +278,7 @@ def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False,
             # numerical array
             return_val = np.allclose(val_1,
                                      val_2,
-                                     rtol=RTC_S1_PRODUCTS_ERROR_REL_TOLERANCE,
-                                     atol=RTC_S1_PRODUCTS_ERROR_ABS_TOLERANCE,
+                                     RTC_S1_PRODUCTS_ERROR_TOLERANCE,
                                      equal_nan=True)
 
             if return_val:
@@ -289,8 +287,7 @@ def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False,
             else:
                 print('\033[91mFAILED.\033[00m', str_message_data_location)
                 print( '    - numerical scalar. Failed to pass the test. '
-                      f'Relative tolerance = {RTC_S1_PRODUCTS_ERROR_REL_TOLERANCE}, '
-                      f'Absolute tolerance = {RTC_S1_PRODUCTS_ERROR_ABS_TOLERANCE}')
+                      f'Tolerance = {RTC_S1_PRODUCTS_ERROR_TOLERANCE}')
                 print(f'    - 1st value: {val_1}')
                 print(f'    - 2nd value: {val_2}\n')
             return return_val
@@ -312,11 +309,7 @@ def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False,
 
         if issubclass(val_1.dtype.type, np.number):
             # val_1 and val_2 are numeric numpy array
-            return_val = np.allclose(val_1,
-                                     val_2,
-                                     rtol=RTC_S1_PRODUCTS_ERROR_REL_TOLERANCE,
-                                     atol=RTC_S1_PRODUCTS_ERROR_ABS_TOLERANCE,
-                                     equal_nan=True)
+            return_val = np.allclose(val_1, val_2, RTC_S1_PRODUCTS_ERROR_TOLERANCE, equal_nan=True)
 
             if return_val:
                 if print_passed_element:
@@ -324,8 +317,7 @@ def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False,
             else:
                 print('\033[91mFAILED.\033[00m', str_message_data_location)
                 print('    - Numerical 1D array. Failed to pass the test. '
-                     f'Relative tolerance = {RTC_S1_PRODUCTS_ERROR_REL_TOLERANCE}, '
-                     f'Absolute tolerance = {RTC_S1_PRODUCTS_ERROR_ABS_TOLERANCE}')
+                     f'Tolerance = {RTC_S1_PRODUCTS_ERROR_TOLERANCE}')
                 print_data_difference(val_1, val_2)
             return return_val
 
@@ -342,18 +334,16 @@ def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False,
 
     if len(shape_val_1) >= 2:
         return_val = np.allclose(val_1,
-                                 val_2,
-                                 rtol=RTC_S1_PRODUCTS_ERROR_REL_TOLERANCE,
-                                 atol=RTC_S1_PRODUCTS_ERROR_ABS_TOLERANCE,
-                                 equal_nan=True)
+                             val_2,
+                             RTC_S1_PRODUCTS_ERROR_TOLERANCE,
+                             equal_nan=True)
         if return_val:
             if print_passed_element:
                 print('\033[32mPASSED.\033[00m', str_message_data_location)
         else:
             print('\033[91mFAILED.\033[00m', str_message_data_location)
             print(f'    {len(shape_val_1)}D raster array. Failed to pass the test. '
-                  f'Relative tolerance = {RTC_S1_PRODUCTS_ERROR_REL_TOLERANCE}, '
-                  f'Absolute tolerance = {RTC_S1_PRODUCTS_ERROR_ABS_TOLERANCE}')
+                  f'Tolerance = {RTC_S1_PRODUCTS_ERROR_TOLERANCE}')
             print_data_difference(val_1, val_2)
         return return_val
 
@@ -497,29 +487,23 @@ def compare_rtc_hdf5_files(file_1, file_2):
         if all(list_flag_identical_dataset):
             print( '    \033[32mPASSED\033[00m: '
                    'The datasets of the two HDF files are the same within '
-                   'the tolerance.')
-            print(f'            Relative tolerance = {RTC_S1_PRODUCTS_ERROR_REL_TOLERANCE}, '
-                  f'Absolute tolerance = {RTC_S1_PRODUCTS_ERROR_ABS_TOLERANCE}')
+                  f'the threshold of {RTC_S1_PRODUCTS_ERROR_TOLERANCE}')
         else:
             print( '    \033[91mFAILED\033[00m: '
                   f'{sum(~np.array(list_flag_identical_dataset))} datasets '
-                  f'out of {len(intersection_set_dataset)} are not the same. ')
-            print(f'            Relative tolerance = {RTC_S1_PRODUCTS_ERROR_REL_TOLERANCE}, '
-                  f'Absolute tolerance = {RTC_S1_PRODUCTS_ERROR_ABS_TOLERANCE}')
+                  f'out of {len(intersection_set_dataset)} are not the same. '
+                  f'Tolerance = {RTC_S1_PRODUCTS_ERROR_TOLERANCE}.')
 
         # Closeness of the common attributes
         if all(list_flag_identical_attrs):
             print( '    \033[32mPASSED\033[00m: '
                    'The attributes of the two HDF files are the same within '
-                   'the tolerance')
-            print(f'            Relative tolerance = {RTC_S1_PRODUCTS_ERROR_REL_TOLERANCE}, '
-                  f'Absolute tolerance = {RTC_S1_PRODUCTS_ERROR_ABS_TOLERANCE}')
+                  f'the threshold of {RTC_S1_PRODUCTS_ERROR_TOLERANCE}\n')
         else:
             print(f'    \033[91mFAILED\033[00m: '
                   f'{sum(~np.array(list_flag_identical_attrs))} attributes '
-                  f'out of {len(intersection_set_attrs)} are not the same.')
-            print(f'            Relative tolerance = {RTC_S1_PRODUCTS_ERROR_REL_TOLERANCE}, '
-                  f'Absolute tolerance = {RTC_S1_PRODUCTS_ERROR_ABS_TOLERANCE}')
+                  f'out of {len(intersection_set_attrs)} are not the same. '
+                  f'Tolerance = {RTC_S1_PRODUCTS_ERROR_TOLERANCE}.\n')
 
         return final_result
 

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -429,48 +429,74 @@ def compare_rtc_hdf5_files(file_1, file_2):
                         flag_same_dataset and
                         flag_same_attributes)
 
-        print('\n\nTest completed.')
+        # Print out the dataset / attribute structure discrepancy if there are any
+        if not flag_identical_dataset_structure:
+            print('    \n\033[91mFAILED\033[00m: Dataset structure not identical.')
+            print('    In the 1st HDF5, not in the 2nd data:')
+            list_dataset_1st_only = list(set_dataset_1 - set_dataset_2)
+            list_dataset_1st_only.sort()
+            list_dataset_2nd_only = list(set_dataset_2 - set_dataset_1)
+            list_dataset_2nd_only.sort()
+            print('\n'.join(list_dataset_1st_only))
+            print('    In the 2st HDF5, not in the 1nd data:')
+            print('\n'.join(list_dataset_2nd_only))
 
-        if flag_identical_dataset_structure:
-            print('\n\033[32mPASSED\033[00m: Dataset structure identical.')
-        else:
-            print('\n\033[91mFAILED\033[00m: Dataset structure not identical.')
-            print('In the 1st HDF5, not in the 2nd data:')
-            print('\n'.join(list(set_dataset_1 - set_dataset_2)))
-            print('In the 2st HDF5, not in the 1nd data:')
-            print('\n'.join(list(set_dataset_2 - set_dataset_1)))
-
-        if flag_identical_attrs_structure:
-            print('\033[32mPASSED\033[00m: Attribute structure identical.')
-
-        else:
-            flag_identical_attrs_structure = False
-            print('\n\033[91mFAILED\033[00m: '
+        if not flag_identical_attrs_structure:
+            print('    \n\033[91mFAILED\033[00m: '
                   'Attribute structure not identical.')
-            print('In the 1st HDF5, not in the 2nd data:')
-            print('\n'.join(list(set_dataset_1 - set_dataset_2)))
-            print('In the 2nd HDF5, not in the 1st data:')
-            print('\n'.join(list(set_dataset_2 - set_dataset_1)))
+            list_attrs_1st_only = list(set_attrs_1 - set_attrs_2)
+            list_attrs_1st_only.sort()
+            list_attrs_2nd_only = list(set_attrs_2 - set_attrs_1)
+            list_attrs_2nd_only.sort()
+            print('    In the 1st HDF5, not in the 2nd data:')
+            print('\n'.join(list_attrs_1st_only))
+            print('    In the 2nd HDF5, not in the 1st data:')
+            print('\n'.join(list_attrs_2nd_only))
 
+        # Print the test summary
+        print('\nTest summary:')
+
+        # Dataset structure
+        if flag_identical_dataset_structure:
+            print('    \033[32mPASSED\033[00m: Same dataset structure confirmed.')
+        else:
+            print( '    \033[91mFAILED\033[00m: '
+                  f'{len(list_dataset_1st_only)} datasets from the 1st HDF are'
+                   ' not found in the 2nd file.'
+                  f'{len(list_dataset_2nd_only)} datasets from the 2nd HDF are'
+                   ' not found in the 1st file.')
+
+        # Attributes structure
+        if flag_identical_attrs_structure:
+            print('    \033[32mPASSED\033[00m: Same attributes structure confirmed.')
+        else:
+            print( '    \033[91mFAILED\033[00m: '
+                  f'{len(list_attrs_1st_only)} attributes from the 1st HDF are'
+                   ' not found in the 2nd file.'
+                  f'{len(list_attrs_2nd_only)} attributes from the 2nd HDF are'
+                   ' not found in the 1st file.')
+
+        # Closeness of the common dataset
         if all(list_flag_identical_dataset):
-            print( '\033[32mPASSED\033[00m: '
+            print( '    \033[32mPASSED\033[00m: '
                    'The datasets of the two HDF files are the same within the'
                   f'threshold of {RTC_S1_PRODUCTS_ERROR_TOLERANCE}')
         else:
-            print( '\033[91mFAILED\033[00m: '
+            print( '    \033[91mFAILED\033[00m: '
                   f'{sum(~np.array(list_flag_identical_dataset))} datasets '
-                  f'out of {len(intersection_set_dataset)}'
-                   'did not pass the test.')
+                  f'out of {len(intersection_set_dataset)} are not the same. '
+                  f'Tolerance = {RTC_S1_PRODUCTS_ERROR_TOLERANCE}.')
 
+        # Closeness of the common attributes
         if all(list_flag_identical_attrs):
-            print( '\033[32mPASSED\033[00m: '
+            print( '    \033[32mPASSED\033[00m: '
                    'The attributes of the two HDF files are the same within '
                   f'the threshold of {RTC_S1_PRODUCTS_ERROR_TOLERANCE}\n')
         else:
-            print(f'\033[91mFAILED\033[00m: '
-                  f' {sum(~np.array(list_flag_identical_attrs))} '
-                  f'attributes out of {len(intersection_set_attrs)} '
-                   'did not pass the test.\n')
+            print(f'    \033[91mFAILED\033[00m: '
+                  f'{sum(~np.array(list_flag_identical_attrs))} attributes '
+                  f'out of {len(intersection_set_attrs)} are not the same. '
+                  f'Tolerance = {RTC_S1_PRODUCTS_ERROR_TOLERANCE}.')
 
         return final_result
 

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -51,9 +51,9 @@ def print_data_difference(val_1, val_2, indent=4):
         # Non-numerical array
         flag_discrepancy = (val_1 != val_2)
         index_first_discrepancy = np.where(flag_discrepancy)[0][0]
-        print('The first discrepancy has detected from index '
-             f'[{index_first_discrepancy}] : '
-             f'1st=({val_1[index_first_discrepancy]}), 2nd=({val_2[index_first_discrepancy]})')
+        print(f'{str_indent} The first discrepancy has detected from index '
+              f'[{index_first_discrepancy}] : '
+              f'1st=({val_1[index_first_discrepancy]}), 2nd=({val_2[index_first_discrepancy]})')
 
 
 

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -237,7 +237,7 @@ def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
             return_val = np.array_equal(val_1, val_2, equal_nan=True)
             if not return_val:
                 print('    - Numerical array. Failed to pass np.array_equal()')
-                printout_data_difference(val_1, val_2)
+                print_data_difference(val_1, val_2)
             return return_val
 
         # All other cases, including the npy array with bytes
@@ -255,7 +255,7 @@ def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
                              equal_nan=True)
         if not return_val:
             print(f'    {len(shape_val_1)}D raster array. Failed to pass np.allclose()')
-            printout_data_difference(val_1, val_2)
+            print_data_difference(val_1, val_2)
         return return_val
 
     # If the processing has reached here, that means
@@ -311,10 +311,10 @@ def main():
             print(f'Testing : {id_flag+1:03d} / {len(union_set_dataset):03d},'
                   f' key: {key_dataset} ')
 
-            list_flag_identical_dataset[id_flag] = compare_hdf5_element(hdf5_in_1,
-                                                                        hdf5_in_2,
-                                                                        key_dataset,
-                                                                        is_attr=False)
+            list_flag_identical_dataset[id_flag] = compare_hdf5_elements(hdf5_in_1,
+                                                                         hdf5_in_2,
+                                                                         key_dataset,
+                                                                         is_attr=False)
             if list_flag_identical_dataset[id_flag]:
                 print('\033[32mPASSED.\033[00m\n')
             else:
@@ -345,10 +345,10 @@ def main():
             print(f'Testing : {id_flag+1:03d} / {len(union_set_attrs):03d}, '
                   f'path - key: {str_printout}')
 
-            list_flag_identical_attrs[id_flag] = compare_hdf5_element(hdf5_in_1,
-                                                                      hdf5_in_2,
-                                                                      key_attr,
-                                                                      is_attr=True)
+            list_flag_identical_attrs[id_flag] = compare_hdf5_elements(hdf5_in_1,
+                                                                       hdf5_in_2,
+                                                                       key_attr,
+                                                                       is_attr=True)
             if list_flag_identical_attrs[id_flag]:
                 print('\033[32mPASSED.\033[00m\n')
             else:

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -1,5 +1,5 @@
 '''
-Compare two RTC products if they are equivalent
+Compare two RTC products (in HDF5) if they are equivalent.
 Part of the codes are copied from PROTEUS SAS
 '''
 
@@ -303,18 +303,22 @@ def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
     return False
 
 
-def main():
+def compare_rtc(file_1, file_2):
     '''
-    Main function of the RTC comparison script
-    - Compares the two HDF files by setting one of them as reference
-    - Perform the same comparison abobe by settint the other HDF5 as reference
+    Compare the two RTC products (in HDF5) if they are equivalent
+    within acceptable difference
+
+    Parameters:
+    -----------
+    file_1, file_2: str
+        Path to the RTC products (in HDF5)
+
+    Return:
+    -------
+    _: bool
+        `True` if the two products are equivalent; `False` otherwise
+
     '''
-    parser = _get_parser()
-
-    args = parser.parse_args()
-
-    file_1 = args.input_file[0]
-    file_2 = args.input_file[1]
 
     with h5py.File(file_1,'r') as hdf5_in_1, h5py.File(file_2,'r') as hdf5_in_2:
         list_dataset_1, list_attrs_1 = get_list_dataset_attrs_keys(hdf5_in_1)
@@ -393,7 +397,7 @@ def main():
 
 
         # Print out the test summary:
-        print('\n\n****************** Test summary ******************')
+        print('\n\n********************* Test summary *********************')
         print(f'1st HDF FILE                 : {file_1}')
         print(f'2nd HDF FILE                 : {file_2}')
         print(f'Value tolerance              : {RTC_S1_PRODUCTS_ERROR_TOLERANCE}')
@@ -418,6 +422,24 @@ def main():
                     print(f'{token_key_attr[1]} {token_key_attr[0]}')
 
         print('See the log above in case there are any failed test.')
+
+        # return the final verdict
+        return all(list_flag_identical_dataset) and all(list_flag_identical_attrs)
+
+
+def main():
+    '''
+    main function of the RTC product comparison script
+    '''
+    parser = _get_parser()
+
+    args = parser.parse_args()
+
+    file_1 = args.input_file[0]
+    file_2 = args.input_file[1]
+
+    compare_rtc(file_1, file_2)
+
 
 if __name__ == '__main__':
     main()

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -201,7 +201,7 @@ def compare_hdf5_element(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
                         val_1_new[i_val] = np.str_(hdf5_obj_1[element_1].name)
                     else:
                         val_1_new[i_val] = element_1
-                val_1 = val_1_new
+                val_1 = np.array(val_1_new)
 
         # Repeat the same process for `val_2`
         if 'shape' in dir(val_2[0]):
@@ -216,43 +216,7 @@ def compare_hdf5_element(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
                         val_2_new[i_val] = np.str_(hdf5_obj_2[element_2].name)
                     else:
                         val_2_new[i_val] = element_2
-                val_2 = val_2_new
-
-        if isinstance(val_1, list) and isinstance(val_2, list):
-            # dereferenced val_1 and val_2
-            if len(val_1) != len(val_2):
-                # List shape does not match
-                print(f'    - Data length does not match: {len(val_1)} vs. {len(val_2)}')
-                return False
-
-            for id_element, element_1 in enumerate(val_1):
-                element_2 = val_2[id_element]
-                if element_1.shape != element_2.shape:
-                    print(f'    - Element shape does not match. ID={id_element}, '
-                          f'shape: {element_1.shape} vs. {element_2.shape}')
-                    return False
-
-                if issubclass(element_1.dtype.type, np.number) and\
-                issubclass(element_2.dtype.type, np.number):
-
-                    return_val = not np.allclose(element_1,
-                                                 element_2,
-                                                 RTC_S1_PRODUCTS_ERROR_TOLERANCE,
-                                                 equal_nan=True)
-
-                return_val = np.array_equal(element_1,element_2)
-
-                if not return_val:
-                    print('    - Same element shape but '
-                          'failed to pass np.allclose() or np.array_equal()')
-                    print(f'    - 1st element: {element_1}')
-                    print(f'    - 2nd element: {element_2}')
-
-                return return_val
-
-            # Went through all elements in the list,
-            # and passed the closeness test in the for loop
-            return True
+                val_2 = np.array(val_2_new)
 
         if issubclass(val_1.dtype.type, np.number) and issubclass(val_2.dtype.type, np.number):
             # val_1 and val_2 are numeric numpy array

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -43,8 +43,11 @@ def printout_data_difference(val_1, val_2, indent=4):
         difference_val = val_1 - val_2
         index_max_diff = np.nanargmax(np.abs(difference_val))
 
-        print(f'{str_indent} Maximum difference of {difference_val[index_max_diff]} '
-            f'detected from index [{index_max_diff}]')
+        print(f'{str_indent} Maximum difference detected from index '
+              f'[{index_max_diff}]: '
+              f'1st: ({val_1[index_max_diff]}), 2nd: ({val_2[index_max_diff]}) = '
+              f'diff: ({difference_val[index_max_diff]})')
+
 
     # Check pixel-by-pixel nan / non-nan difference
     if (issubclass(val_1.dtype.type, np.floating) and issubclass(val_2.dtype.type, np.floating)) or\
@@ -62,6 +65,7 @@ def printout_data_difference(val_1, val_2, indent=4):
                    'NaN / not NaN discrepancy detected. '
                   f'First index of the discrepancy: [{index_pixel_nan_discrepancy[0][0]}]')
 
+    # TODO Implement for non-numerical array case
 
 def get_list_dataset_attrs_keys(hdf_obj_1: h5py.Group,
                                 key_in: str='/',

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -102,7 +102,6 @@ def print_data_difference(val_1, val_2, indent=4):
     mask_nan_discrepancy = np.logical_xor(mask_nan_val_1, mask_nan_val_2)
 
     if not np.any(mask_nan_discrepancy):
-        print(f'{str_indent} NaN discrepancy was not detected.')
         return
 
     num_pixel_nan_discrepancy = mask_nan_discrepancy.sum()

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -127,7 +127,7 @@ def get_list_dataset_attrs_keys(hdf_obj_1: h5py.Group,
     return list_dataset_so_far, list_attrs_so_far
 
 
-def compare_hdf5_element(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
+def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
     '''
     Compare the dataset or attribute defined by `str_key`
     NOTE: For attributes, the path and the key are separated by newline character ('\n')

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -437,9 +437,9 @@ def compare_rtc_hdf5_files(file_1, file_2):
             list_dataset_1st_only.sort()
             list_dataset_2nd_only = list(set_dataset_2 - set_dataset_1)
             list_dataset_2nd_only.sort()
-            print('\n'.join(list_dataset_1st_only))
+            print('\n    '.join(list_dataset_1st_only))
             print('    In the 2st HDF5, not in the 1nd data:')
-            print('\n'.join(list_dataset_2nd_only))
+            print('\n    '.join(list_dataset_2nd_only))
 
         if not flag_identical_attrs_structure:
             print('    \n\033[91mFAILED\033[00m: '
@@ -449,9 +449,9 @@ def compare_rtc_hdf5_files(file_1, file_2):
             list_attrs_2nd_only = list(set_attrs_2 - set_attrs_1)
             list_attrs_2nd_only.sort()
             print('    In the 1st HDF5, not in the 2nd data:')
-            print('\n'.join(list_attrs_1st_only))
+            print('\n    '.join(list_attrs_1st_only))
             print('    In the 2nd HDF5, not in the 1st data:')
-            print('\n'.join(list_attrs_2nd_only))
+            print('\n    '.join(list_attrs_2nd_only))
 
         # Print the test summary
         print('\nTest summary:')
@@ -462,8 +462,8 @@ def compare_rtc_hdf5_files(file_1, file_2):
         else:
             print( '    \033[91mFAILED\033[00m: '
                   f'{len(list_dataset_1st_only)} datasets from the 1st HDF are'
-                   ' not found in the 2nd file.'
-                  f'{len(list_dataset_2nd_only)} datasets from the 2nd HDF are'
+                   ' not found in the 2nd file.\n'
+                  f'        {len(list_dataset_2nd_only)} datasets from the 2nd HDF are'
                    ' not found in the 1st file.')
 
         # Attributes structure
@@ -472,15 +472,15 @@ def compare_rtc_hdf5_files(file_1, file_2):
         else:
             print( '    \033[91mFAILED\033[00m: '
                   f'{len(list_attrs_1st_only)} attributes from the 1st HDF are'
-                   ' not found in the 2nd file.'
-                  f'{len(list_attrs_2nd_only)} attributes from the 2nd HDF are'
+                   ' not found in the 2nd file.\n'
+                  f'        {len(list_attrs_2nd_only)} attributes from the 2nd HDF are'
                    ' not found in the 1st file.')
 
         # Closeness of the common dataset
         if all(list_flag_identical_dataset):
             print( '    \033[32mPASSED\033[00m: '
-                   'The datasets of the two HDF files are the same within the'
-                  f'threshold of {RTC_S1_PRODUCTS_ERROR_TOLERANCE}')
+                   'The datasets of the two HDF files are the same within '
+                  f'the threshold of {RTC_S1_PRODUCTS_ERROR_TOLERANCE}')
         else:
             print( '    \033[91mFAILED\033[00m: '
                   f'{sum(~np.array(list_flag_identical_dataset))} datasets '
@@ -496,7 +496,7 @@ def compare_rtc_hdf5_files(file_1, file_2):
             print(f'    \033[91mFAILED\033[00m: '
                   f'{sum(~np.array(list_flag_identical_attrs))} attributes '
                   f'out of {len(intersection_set_attrs)} are not the same. '
-                  f'Tolerance = {RTC_S1_PRODUCTS_ERROR_TOLERANCE}.')
+                  f'Tolerance = {RTC_S1_PRODUCTS_ERROR_TOLERANCE}.\n')
 
         return final_result
 

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -72,7 +72,7 @@ def print_data_difference(val_1, val_2, indent=4):
     str_indent = ' ' * indent + '-'
 
     # printout the difference when the array is numeric
-    if issubclass(val_1.dtype.type, np.number) and issubclass(val_2.dtype.type, np.number):
+    if issubclass(val_1.dtype.type, np.number):
         difference_val = val_1 - val_2
         index_max_diff = np.nanargmax(np.abs(difference_val))
 
@@ -89,13 +89,8 @@ def print_data_difference(val_1, val_2, indent=4):
               f'1st=({val_1[index_first_discrepancy]}), 2nd=({val_2[index_first_discrepancy]})')
 
     # Check pixel-by-pixel nan / non-nan difference
-    is_floating_real_val1 = issubclass(val_1.dtype.type, np.floating)
-    is_floating_real_val2 = issubclass(val_2.dtype.type, np.floating)
-    is_floating_complex_val1 = issubclass(val_1.dtype.type, np.complexfloating)
-    is_floating_complex_val2 = issubclass(val_2.dtype.type, np.complexfloating)
-
-    if ((is_floating_real_val1 and is_floating_real_val2) or
-    (is_floating_complex_val1 and is_floating_complex_val2)):
+    if (issubclass(val_1.dtype.type, np.floating) or
+    issubclass(val_1.dtype.type, np.complexfloating)):
 
         mask_nan_val_1 = np.isnan(val_1)
         mask_nan_val_2 = np.isnan(val_2)
@@ -243,14 +238,17 @@ def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
         print(f'    - Data shapes do not match. {shape_val_1} vs. {shape_val_2}')
         return False
 
+    if val_1.dtype != val_2.dtype:
+        print(f'    - Data types do not match. ({val_1.dtype}) vs. ({val_2.dtype})')
+        return False
+
+
     if len(shape_val_1)==0:
         # Scalar value
         print(f'    - 1st value: {val_1}')
         print(f'    - 2nd value: {val_2}')
 
-        if (issubclass(val_1.dtype.type, np.number) and
-            issubclass(val_2.dtype.type, np.number)):
-
+        if issubclass(val_1.dtype.type, np.number):
             # numerical array
             return_val = np.array_equal(val_1, val_2, equal_nan=True)
             if not return_val:
@@ -266,7 +264,7 @@ def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
     if len(shape_val_1) == 1:
         # 1d vector
 
-        if issubclass(val_1.dtype.type, np.number) and issubclass(val_2.dtype.type, np.number):
+        if issubclass(val_1.dtype.type, np.number):
             # val_1 and val_2 are numeric numpy array
             return_val = np.array_equal(val_1, val_2, equal_nan=True)
             if not return_val:

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -160,7 +160,7 @@ def compare_hdf5_element(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
         print(f'    - Data shapes do not match. {shape_val_1} vs. {shape_val_2}')
         return False
 
-    if len(shape_val_1)==0 and len(shape_val_2)==0:
+    if len(shape_val_1)==0:
         # Scalar value
         print(f'    - 1st value: {val_1}')
         print(f'    - 2nd value: {val_2}')
@@ -180,7 +180,7 @@ def compare_hdf5_element(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
             print('    - non-numerical scalar. Failed to pass np.array_equal()')
         return return_val
 
-    if len(shape_val_1)==1 and len(shape_val_2)==1:
+    if len(shape_val_1)==1:
         # 1d vector
 
         # Dereference if val_1 and val_2 have HDF5 objstc reference.
@@ -234,7 +234,7 @@ def compare_hdf5_element(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
         return return_val
 
 
-    if len(shape_val_1)>=2 and len(shape_val_2)>=2:
+    if len(shape_val_1)>=2:
         return_val = np.allclose(val_1,
                              val_2,
                              RTC_S1_PRODUCTS_ERROR_TOLERANCE,

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -128,6 +128,8 @@ def compare_dataset_attr(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
 
     if len(shape_val_1)==0 and len(shape_val_2)==0:
         # Scalar value
+        print(f'    - 1st value:{val_1}')
+        print(f'    - 2nd value:{val_2}')
         if issubclass(val_1.dtype.type, np.number) and issubclass(val_2.dtype.type, np.number):
             # numerical array
             return_val = np.array_equal(val_1, val_2, equal_nan=True)

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -9,7 +9,8 @@ import itertools
 import h5py
 import numpy as np
 
-RTC_S1_PRODUCTS_ERROR_TOLERANCE = 1e-6
+RTC_S1_PRODUCTS_ERROR_REL_TOLERANCE = 1e-05
+RTC_S1_PRODUCTS_ERROR_ABS_TOLERANCE = 1e-06
 
 def _get_parser():
     parser = argparse.ArgumentParser(
@@ -278,7 +279,8 @@ def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False,
             # numerical array
             return_val = np.allclose(val_1,
                                      val_2,
-                                     RTC_S1_PRODUCTS_ERROR_TOLERANCE,
+                                     rtol=RTC_S1_PRODUCTS_ERROR_REL_TOLERANCE,
+                                     atol=RTC_S1_PRODUCTS_ERROR_ABS_TOLERANCE,
                                      equal_nan=True)
 
             if return_val:
@@ -287,7 +289,8 @@ def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False,
             else:
                 print('\033[91mFAILED.\033[00m', str_message_data_location)
                 print( '    - numerical scalar. Failed to pass the test. '
-                      f'Tolerance = {RTC_S1_PRODUCTS_ERROR_TOLERANCE}')
+                      f'Relative tolerance = {RTC_S1_PRODUCTS_ERROR_REL_TOLERANCE}, '
+                      f'Absolute tolerance = {RTC_S1_PRODUCTS_ERROR_ABS_TOLERANCE}')
                 print(f'    - 1st value: {val_1}')
                 print(f'    - 2nd value: {val_2}\n')
             return return_val
@@ -309,7 +312,11 @@ def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False,
 
         if issubclass(val_1.dtype.type, np.number):
             # val_1 and val_2 are numeric numpy array
-            return_val = np.allclose(val_1, val_2, RTC_S1_PRODUCTS_ERROR_TOLERANCE, equal_nan=True)
+            return_val = np.allclose(val_1,
+                                     val_2,
+                                     rtol=RTC_S1_PRODUCTS_ERROR_REL_TOLERANCE,
+                                     atol=RTC_S1_PRODUCTS_ERROR_ABS_TOLERANCE,
+                                     equal_nan=True)
 
             if return_val:
                 if print_passed_element:
@@ -317,7 +324,8 @@ def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False,
             else:
                 print('\033[91mFAILED.\033[00m', str_message_data_location)
                 print('    - Numerical 1D array. Failed to pass the test. '
-                     f'Tolerance = {RTC_S1_PRODUCTS_ERROR_TOLERANCE}')
+                     f'Relative tolerance = {RTC_S1_PRODUCTS_ERROR_REL_TOLERANCE}, '
+                     f'Absolute tolerance = {RTC_S1_PRODUCTS_ERROR_ABS_TOLERANCE}')
                 print_data_difference(val_1, val_2)
             return return_val
 
@@ -334,16 +342,18 @@ def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False,
 
     if len(shape_val_1) >= 2:
         return_val = np.allclose(val_1,
-                             val_2,
-                             RTC_S1_PRODUCTS_ERROR_TOLERANCE,
-                             equal_nan=True)
+                                 val_2,
+                                 rtol=RTC_S1_PRODUCTS_ERROR_REL_TOLERANCE,
+                                 atol=RTC_S1_PRODUCTS_ERROR_ABS_TOLERANCE,
+                                 equal_nan=True)
         if return_val:
             if print_passed_element:
                 print('\033[32mPASSED.\033[00m', str_message_data_location)
         else:
             print('\033[91mFAILED.\033[00m', str_message_data_location)
             print(f'    {len(shape_val_1)}D raster array. Failed to pass the test. '
-                  f'Tolerance = {RTC_S1_PRODUCTS_ERROR_TOLERANCE}')
+                  f'Relative tolerance = {RTC_S1_PRODUCTS_ERROR_REL_TOLERANCE}, '
+                  f'Absolute tolerance = {RTC_S1_PRODUCTS_ERROR_ABS_TOLERANCE}')
             print_data_difference(val_1, val_2)
         return return_val
 
@@ -487,23 +497,29 @@ def compare_rtc_hdf5_files(file_1, file_2):
         if all(list_flag_identical_dataset):
             print( '    \033[32mPASSED\033[00m: '
                    'The datasets of the two HDF files are the same within '
-                  f'the threshold of {RTC_S1_PRODUCTS_ERROR_TOLERANCE}')
+                   'the tolerance.')
+            print(f'            Relative tolerance = {RTC_S1_PRODUCTS_ERROR_REL_TOLERANCE}, '
+                  f'Absolute tolerance = {RTC_S1_PRODUCTS_ERROR_ABS_TOLERANCE}')
         else:
             print( '    \033[91mFAILED\033[00m: '
                   f'{sum(~np.array(list_flag_identical_dataset))} datasets '
-                  f'out of {len(intersection_set_dataset)} are not the same. '
-                  f'Tolerance = {RTC_S1_PRODUCTS_ERROR_TOLERANCE}.')
+                  f'out of {len(intersection_set_dataset)} are not the same. ')
+            print(f'            Relative tolerance = {RTC_S1_PRODUCTS_ERROR_REL_TOLERANCE}, '
+                  f'Absolute tolerance = {RTC_S1_PRODUCTS_ERROR_ABS_TOLERANCE}')
 
         # Closeness of the common attributes
         if all(list_flag_identical_attrs):
             print( '    \033[32mPASSED\033[00m: '
                    'The attributes of the two HDF files are the same within '
-                  f'the threshold of {RTC_S1_PRODUCTS_ERROR_TOLERANCE}\n')
+                   'the tolerance')
+            print(f'            Relative tolerance = {RTC_S1_PRODUCTS_ERROR_REL_TOLERANCE}, '
+                  f'Absolute tolerance = {RTC_S1_PRODUCTS_ERROR_ABS_TOLERANCE}')
         else:
             print(f'    \033[91mFAILED\033[00m: '
                   f'{sum(~np.array(list_flag_identical_attrs))} attributes '
-                  f'out of {len(intersection_set_attrs)} are not the same. '
-                  f'Tolerance = {RTC_S1_PRODUCTS_ERROR_TOLERANCE}.\n')
+                  f'out of {len(intersection_set_attrs)} are not the same.')
+            print(f'            Relative tolerance = {RTC_S1_PRODUCTS_ERROR_REL_TOLERANCE}, '
+                  f'Absolute tolerance = {RTC_S1_PRODUCTS_ERROR_ABS_TOLERANCE}')
 
         return final_result
 

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -303,7 +303,7 @@ def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
     return False
 
 
-def compare_rtc(file_1, file_2):
+def compare_rtc_hdf5_files(file_1, file_2):
     '''
     Compare the two RTC products (in HDF5) if they are equivalent
     within acceptable difference
@@ -402,7 +402,7 @@ def compare_rtc(file_1, file_2):
         print(f'2nd HDF FILE                 : {file_2}')
         print(f'Value tolerance              : {RTC_S1_PRODUCTS_ERROR_TOLERANCE}')
         print(f'\nIdentical dataset structure  : {flag_identical_dataset_structure}')
-        print(f'Identical Attribute structure: {flag_identical_attrs_structure}\n')
+        print(f'Identical attribute structure: {flag_identical_attrs_structure}\n')
 
         if all(list_flag_identical_dataset):
             print('All dataset passed the test')
@@ -419,9 +419,9 @@ def compare_rtc(file_1, file_2):
             for id_attr, key_attr in enumerate(union_set_attrs):
                 if not list_flag_identical_attrs[id_attr]:
                     token_key_attr=key_attr.split('\n')
-                    print(f'{token_key_attr[1]} {token_key_attr[0]}')
+                    print(f'\'{token_key_attr[1]}\' in {token_key_attr[0]}')
 
-        print('See the log above in case there are any failed test.')
+        print('\nSee the log above in case there are any failed test.\n')
 
         # return the final verdict
         return all(list_flag_identical_dataset) and all(list_flag_identical_attrs)
@@ -438,7 +438,7 @@ def main():
     file_1 = args.input_file[0]
     file_2 = args.input_file[1]
 
-    compare_rtc(file_1, file_2)
+    compare_rtc_hdf5_files(file_1, file_2)
 
 
 if __name__ == '__main__':

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -69,8 +69,8 @@ def print_data_difference(val_1, val_2, indent=4):
         if np.any(mask_nan_discrepancy):
             num_pixel_nan_discrepancy = mask_nan_discrepancy.sum()
             index_pixel_nan_discrepancy = np.where(mask_nan_discrepancy)
-            print(f'{str_indent} {num_pixel_nan_discrepancy} of '
-                   'NaN / not NaN discrepancy detected. '
+            print(f'{str_indent} Found {num_pixel_nan_discrepancy} '
+                   'inconsistent values between input arrays. '
                   f'First index of the discrepancy: [{index_pixel_nan_discrepancy[0][0]}]')
 
 def get_list_dataset_attrs_keys(hdf_obj_1: h5py.Group,

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -213,7 +213,7 @@ def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False,
 
     Return:
     -------
-    _: True when the dataset / attribute are identical; False otherwise
+    _: True when the dataset / attribute are equivalent; False otherwise
     '''
 
 

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -24,7 +24,7 @@ def _get_parser():
 
     return parser
 
-def printout_data_difference(val_1, val_2, indent=4):
+def print_data_difference(val_1, val_2, indent=4):
     '''
     Print out the diffrence of the data whose dimension is >= 1
 

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -434,39 +434,45 @@ def compare_rtc_hdf5_files(file_1, file_2):
         print('\n\nTest completed.')
 
         if flag_identical_dataset_structure:
-            print('\nDataset structure identical.')
+            print('\n\033[32mPASSED\033[00m: Dataset structure identical.')
         else:
-            print('\nDataset structure not identical.')
+            print('\n\033[91mFAILED\033[00m: Dataset structure not identical.')
             print('In the 1st HDF5, not in the 2nd data:')
             print('\n'.join(list(set_dataset_1 - set_dataset_2)))
             print('In the 2st HDF5, not in the 1nd data:')
             print('\n'.join(list(set_dataset_2 - set_dataset_1)))
 
         if flag_identical_attrs_structure:
-            print('Attribute structure identical.')
+            print('\033[32mPASSED\033[00m: Attribute structure identical.')
 
         else:
             flag_identical_attrs_structure = False
-            print('\nAttribute structure not identical.')
+            print('\n\033[91mFAILED\033[00m: '
+                  'Attribute structure not identical.')
             print('In the 1st HDF5, not in the 2nd data:')
             print('\n'.join(list(set_dataset_1 - set_dataset_2)))
             print('In the 2nd HDF5, not in the 1st data:')
             print('\n'.join(list(set_dataset_2 - set_dataset_1)))
 
         if all(list_flag_identical_dataset):
-            print( 'The datasets of the two HDF files are the same within '
-                  f'the threshold of {RTC_S1_PRODUCTS_ERROR_TOLERANCE}')
+            print( '\033[32mPASSED\033[00m: '
+                   'The datasets of the two HDF files are the same within the'
+                  f'threshold of {RTC_S1_PRODUCTS_ERROR_TOLERANCE}')
         else:
-            print(f'{sum(~np.array(list_flag_identical_dataset))} datasets out of '
-                  f'{len(intersection_set_dataset)} did not pass the test.')
+            print( '\033[91mFAILED\033[00m: '
+                  f'{sum(~np.array(list_flag_identical_dataset))} datasets '
+                  f'out of {len(intersection_set_dataset)}'
+                   'did not pass the test.')
 
         if all(list_flag_identical_attrs):
-            print( 'The attributes of the two HDF files are the same within '
+            print( '\033[32mPASSED\033[00m: '
+                   'The attributes of the two HDF files are the same within '
                   f'the threshold of {RTC_S1_PRODUCTS_ERROR_TOLERANCE}\n')
         else:
-            print(f'{sum(~np.array(list_flag_identical_attrs))} attributes out of '
-                  f'{len(intersection_set_attrs)} did not pass the test.\n')
-
+            print(f'\033[91mFAILED\033[00m: '
+                  f' {sum(~np.array(list_flag_identical_attrs))} '
+                  f'attributes out of {len(intersection_set_attrs)} '
+                   'did not pass the test.\n')
 
         return final_result
 

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -194,7 +194,7 @@ def compare_hdf5_element(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
             print('    - non-numerical scalar. Failed to pass np.array_equal()')
         return return_val
 
-    if len(shape_val_1)==1:
+    if len(shape_val_1) == 1:
         # 1d vector
 
         # Dereference if val_1 and val_2 have HDF5 objstc reference.

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -47,6 +47,14 @@ def printout_data_difference(val_1, val_2, indent=4):
               f'[{index_max_diff}]: '
               f'1st: ({val_1[index_max_diff]}), 2nd: ({val_2[index_max_diff]}) = '
               f'diff: ({difference_val[index_max_diff]})')
+    else:
+        # Non-numerical array
+        flag_discrepancy = (val_1 != val_2)
+        index_first_discrepancy = np.where(flag_discrepancy)[0][0]
+        print('The first discrepancy has detected from index '
+             f'[{index_first_discrepancy}] : '
+             f'1st=({val_1[index_first_discrepancy]}), 2nd=({val_2[index_first_discrepancy]})')
+
 
 
     # Check pixel-by-pixel nan / non-nan difference
@@ -64,8 +72,6 @@ def printout_data_difference(val_1, val_2, indent=4):
             print(f'{str_indent} {num_pixel_nan_discrepancy} of '
                    'NaN / not NaN discrepancy detected. '
                   f'First index of the discrepancy: [{index_pixel_nan_discrepancy[0][0]}]')
-
-    # TODO Implement for non-numerical array case
 
 def get_list_dataset_attrs_keys(hdf_obj_1: h5py.Group,
                                 key_in: str='/',

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -26,7 +26,7 @@ def _get_parser():
 
 def print_data_difference(val_1, val_2, indent=4):
     '''
-    Print out the diffrence of the data whose dimension is >= 1
+    Print out the difference of the data whose dimension is >= 1
 
     Parameters:
     -----------

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -248,7 +248,7 @@ def compare_hdf5_element(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
         return return_val
 
 
-    if len(shape_val_1)>=2:
+    if len(shape_val_1) >= 2:
         return_val = np.allclose(val_1,
                              val_2,
                              RTC_S1_PRODUCTS_ERROR_TOLERANCE,

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -134,7 +134,7 @@ def get_list_dataset_attrs_keys(hdf_obj_1: h5py.Group,
                                 list_attrs_so_far: list=None):
 
     '''
-    Recursively traverse the Dataset and Attributes in the input HDF5 object.
+    Recursively traverse the datasets and attributes within the input HDF5 group.
     Returns the list of keys for the dataset and the attributes.
 
     NOTE:

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -349,8 +349,7 @@ def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False,
             print_data_difference(val_1, val_2)
         return return_val
 
-    # If the processing has reached here, that means
-    # val_1 and val_2 cannot be compated due to their shape difference
+    # Unnexpected dataset shape
     print('    - Detected an issue on the dataset shapes: ',
             f'Dataset key: {str_key}, '
             'dataset shape in the 1st HDF5: ', shape_val_1,

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -81,7 +81,7 @@ def print_data_difference(val_1, val_2, indent=4):
               f'[{index_first_discrepancy}] : '
               f'1st=({val_1[index_first_discrepancy]}), '
               f'2nd=({val_2[index_first_discrepancy]})')
-        return None
+        return
 
     # Routine for numeric array
     difference_val = val_1 - val_2
@@ -93,7 +93,7 @@ def print_data_difference(val_1, val_2, indent=4):
 
     if not (issubclass(val_1.dtype.type, np.floating) or
             issubclass(val_1.dtype.type, np.complexfloating)):
-        return None
+        return
 
     # Check pixel-by-pixel nan / non-nan difference
     mask_nan_val_1 = np.isnan(val_1)
@@ -103,7 +103,7 @@ def print_data_difference(val_1, val_2, indent=4):
 
     if not np.any(mask_nan_discrepancy):
         print(f'{str_indent} NaN discrepancy was not detected.')
-        return None
+        return
 
     num_pixel_nan_discrepancy = mask_nan_discrepancy.sum()
     index_pixel_nan_discrepancy = np.where(mask_nan_discrepancy)
@@ -157,7 +157,8 @@ def get_list_dataset_attrs_keys(hdf_obj_1: h5py.Group,
     list_dataset_so_far : list
         List of datasets keys found for given HDF5 group
     list_attrs_so_far : list
-        List of attributes found for given HDF5 group. Each attribute is identified by its path and key (attribute name).
+        List of attributes found for given HDF5 group.
+        Each attribute is identified by its path and key (attribute name).
 
     '''
 

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -240,13 +240,13 @@ def compare_hdf5_elements(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False,
     # /science/CSAR/RTC/grids/frequencyA/xCoordinates'
     # attribute `DIMENSION_LIST` in
     # /science/CSAR/RTC/grids/frequencyA/VH
-    if (len(val_1.shape)>=1) and ('shape' in dir(val_1[0])):
+    if (len(val_1.shape) >= 1) and ('shape' in dir(val_1[0])):
         if (isinstance(val_1[0], np.void) or
         ((len(val_1[0].shape) == 1) and (isinstance(val_1[0][0], h5py.h5r.Reference)))):
             val_1 = _unpack_array(val_1, hdf5_obj_1)
 
     # Repeat the same process for val_2
-    if (len(val_2.shape)>=1) and ('shape' in dir(val_2[0])):
+    if (len(val_2.shape) >= 1) and ('shape' in dir(val_2[0])):
         if (isinstance(val_2[0], np.void) or
         ((len(val_2[0].shape) == 1) and (isinstance(val_2[0][0], h5py.h5r.Reference)))):
             val_2 = _unpack_array(val_2, hdf5_obj_2)
@@ -377,44 +377,44 @@ def compare_rtc_hdf5_files(file_1, file_2):
 
         # Check the dataset
         print('Checking the dataset.')
-        union_set_dataset = set_dataset_1.union(set_dataset_2)
+        intersection_set_dataset = set_dataset_1.intersection(set_dataset_2)
         flag_identical_dataset_structure = \
-            (len(union_set_dataset) == len(set_dataset_1) and
-             len(union_set_dataset) == len(set_dataset_2))
+            (len(intersection_set_dataset) == len(set_dataset_1) and
+             len(intersection_set_dataset) == len(set_dataset_2))
 
         # Proceed with checking the values in dataset,
         # regardless of the agreement of their structure.
-        list_flag_identical_dataset = [None] * len(union_set_dataset)
-        for id_flag, key_dataset in enumerate(union_set_dataset):
+        list_flag_identical_dataset = [None] * len(intersection_set_dataset)
+        for id_flag, key_dataset in enumerate(intersection_set_dataset):
             list_flag_identical_dataset[id_flag] = \
                 compare_hdf5_elements(hdf5_in_1,
                                       hdf5_in_2,
                                       key_dataset,
                                       is_attr=False,
                                       id_key=id_flag,
-                                      total_key=len(union_set_dataset),
+                                      total_key=len(intersection_set_dataset),
                                       print_passed_element=True)
 
         print('\nChecking the attributes.')
         # Check the attribute
-        union_set_attrs = set_attrs_1.union(set_attrs_2)
+        intersection_set_attrs = set_attrs_1.intersection(set_attrs_2)
 
         flag_identical_attrs_structure = \
-            (len(union_set_attrs) == len(set_attrs_1) and
-             len(union_set_attrs) == len(set_attrs_2))
+            (len(intersection_set_attrs) == len(set_attrs_1) and
+             len(intersection_set_attrs) == len(set_attrs_2))
 
         # Proceed with checking the values in attributes,
         # regardless of the agreement of their structure.
 
-        list_flag_identical_attrs = [None] * len(union_set_attrs)
-        for id_flag, key_attr in enumerate(union_set_attrs):
+        list_flag_identical_attrs = [None] * len(intersection_set_attrs)
+        for id_flag, key_attr in enumerate(intersection_set_attrs):
             list_flag_identical_attrs[id_flag] = \
                 compare_hdf5_elements(hdf5_in_1,
                                       hdf5_in_2,
                                       key_attr,
                                       is_attr=True,
                                       id_key=id_flag,
-                                      total_key=len(union_set_attrs),
+                                      total_key=len(intersection_set_attrs),
                                       print_passed_element=False)
 
         flag_same_dataset = all(list_flag_identical_dataset)
@@ -452,14 +452,14 @@ def compare_rtc_hdf5_files(file_1, file_2):
                   f'the threshold of {RTC_S1_PRODUCTS_ERROR_TOLERANCE}')
         else:
             print(f'{sum(~np.array(list_flag_identical_dataset))} datasets out of '
-                  f'{len(union_set_dataset)} did not pass the test.')
+                  f'{len(intersection_set_dataset)} did not pass the test.')
 
         if all(list_flag_identical_attrs):
             print( 'The attributes of the two HDF files are the same within '
                   f'the threshold of {RTC_S1_PRODUCTS_ERROR_TOLERANCE}\n')
         else:
             print(f'{sum(~np.array(list_flag_identical_attrs))} attributes out of '
-                  f'{len(union_set_attrs)} did not pass the test.\n')
+                  f'{len(intersection_set_attrs)} did not pass the test.\n')
 
 
         return final_result

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -429,7 +429,7 @@ def compare_rtc_hdf5_files(file_1, file_2):
                         flag_same_dataset and
                         flag_same_attributes)
 
-        # Print out the dataset / attribute structure discrepancy if there are any
+        # Print out the dataset structure discrepancy if there are any
         if not flag_identical_dataset_structure:
             print('    \n\033[91mFAILED\033[00m: Dataset structure not identical.')
             print('In the 1st HDF5, not in the 2nd data:')
@@ -437,27 +437,28 @@ def compare_rtc_hdf5_files(file_1, file_2):
             list_dataset_1st_only.sort()
             list_dataset_2nd_only = list(set_dataset_2 - set_dataset_1)
             list_dataset_2nd_only.sort()
-            print('\n    '+'\n    '.join(list_dataset_1st_only))
+            print('    '+'\n    '.join(list_dataset_1st_only))
             print('\nIn the 2st HDF5, not in the 1nd data:')
-            print('\n    '+'\n    '.join(list_dataset_2nd_only))
+            print('    '+'\n    '.join(list_dataset_2nd_only))
 
-        if not flag_identical_attrs_structure:
+        # Print out the attribute structure discrepancy if there are any.
+        # Omitting the print out when the dataset structure is not identical
+        list_attrs_1st_only = list(set_attrs_1 - set_attrs_2)
+        list_attrs_1st_only.sort()
+        list_attrs_2nd_only = list(set_attrs_2 - set_attrs_1)
+        list_attrs_2nd_only.sort()
+        if (not flag_identical_attrs_structure) and flag_identical_dataset_structure:
             print('    \n\033[91mFAILED\033[00m: '
                   'Attribute structure not identical.')
-            list_attrs_1st_only = list(set_attrs_1 - set_attrs_2)
-            list_attrs_1st_only.sort()
-            list_attrs_2nd_only = list(set_attrs_2 - set_attrs_1)
-            list_attrs_2nd_only.sort()
-
             print('In the 1st HDF5, not in the 2nd data:')
             print('\r    ' +
                   '\r    '.join(list_attrs_1st_only).\
-                  replace('\n', ',\tkey = ').replace('\r', '\n'))
+                  replace('\n', ',\tattr: ').replace('\r', '\n'))
 
             print('\nIn the 2nd HDF5, not in the 1st data:')
             print('\r    ' +
                   '\r    '.join(list_attrs_2nd_only).\
-                  replace('\n', ',\tkey = ').replace('\r', '\n'))
+                  replace('\n', ',\tattr: ').replace('\r', '\n'))
 
         # Print the test summary
         print('\nTest summary:')

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -248,19 +248,19 @@ def main():
 
         # Proceed with checking the values in dataset,
         # regardless of the agreement of their structure.
-
         list_flag_identical_dataset = [None] * len(union_set_dataset)
         for id_flag, key_dataset in enumerate(union_set_dataset):
+            print(f'Testing : {id_flag+1:03d} / {len(union_set_dataset):03d},'
+                  f' key: {key_dataset} ')
+
             list_flag_identical_dataset[id_flag] = compare_dataset_attr(hdf5_in_1,
                                                                         hdf5_in_2,
                                                                         key_dataset,
                                                                         is_attr=False)
             if list_flag_identical_dataset[id_flag]:
-                print(f'{id_flag+1:03d} / {len(union_set_dataset):03d} : '
-                      f'PASSED. key: {key_dataset}')
+                print('PASSED.\n')
             else:
-                print(f'\033[91m{id_flag+1:03d} / {len(union_set_dataset):03d} : '
-                      f'FAILED. key: {key_dataset}\033[00m')
+                print('\033[91mFAILED.\033[00m\n')
 
         # Check the attribute
         union_set_attrs = set_attrs_1.union(set_attrs_2)
@@ -283,17 +283,18 @@ def main():
 
         list_flag_identical_attrs = [None] * len(union_set_attrs)
         for id_flag, key_attr in enumerate(union_set_attrs):
+            str_printout = key_attr.replace('\n',' - ')
+            print(f'Testing : {id_flag+1:03d} / {len(union_set_attrs):03d}, '
+                  f'path - key: {str_printout}')
+
             list_flag_identical_attrs[id_flag] = compare_dataset_attr(hdf5_in_1,
                                                                       hdf5_in_2,
                                                                       key_attr,
                                                                       is_attr=True)
-            str_printout = key_attr.replace('\n',' - ')
             if list_flag_identical_attrs[id_flag]:
-                print(f'{id_flag+1:03d} / {len(union_set_attrs):03d} : '
-                      f'PASSED. path - key: {str_printout}')
+                print('PASSED.\n')
             else:
-                print(f'\033[91m{id_flag+1:03d} / {len(union_set_attrs):03d} : '
-                      f'FAILED. path - key: {str_printout}\033[00m')
+                print('\033[91mFAILED.\033[00m\n')
 
 
         # Print out the test summary:

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -294,9 +294,10 @@ def main():
         flag_identical_dataset_structure = \
             (len(union_set_dataset) == len(set_dataset_1) and
              len(union_set_dataset) == len(set_dataset_2))
-         if flag_identical_dataset_structure:
+
+        if flag_identical_dataset_structure:
             print('\nDataset structure identical.')
-         else:
+        else:
             print('\nDataset structure not identical.')
             print('In the 1st HDF5, not in the 2nd data:')
             print('\n'.join(list(set_dataset_1 - set_dataset_2)))
@@ -322,9 +323,11 @@ def main():
         # Check the attribute
         union_set_attrs = set_attrs_1.union(set_attrs_2)
 
-        if (len(union_set_attrs) == len(set_attrs_1) and
-            len(union_set_attrs) == len(set_attrs_2)):
-            flag_identical_attrs_structure = True
+        flag_identical_attrs_structure = \
+        (len(union_set_attrs) == len(set_attrs_1) and
+         len(union_set_attrs) == len(set_attrs_2))
+
+        if flag_identical_attrs_structure:
             print('\nAttribute structure identical.')
 
         else:
@@ -337,7 +340,6 @@ def main():
 
         # Proceed with checking the values in dataset,
         # regardless of the agreement of their structure.
-
         list_flag_identical_attrs = [None] * len(union_set_attrs)
         for id_flag, key_attr in enumerate(union_set_attrs):
             str_printout = key_attr.replace('\n',' - ')

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -154,7 +154,10 @@ def get_list_dataset_attrs_keys(hdf_obj_1: h5py.Group,
 
     Return:
     -------
-    _ : 0 if the two HDF are identical; 1 otherwise
+    list_dataset_so_far : list
+        List of datasets keys found for given HDF5 group
+    list_attrs_so_far : list
+        List of attributes found for given HDF5 group. Each attribute is identified by its path and key (attribute name).
 
     '''
 

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -130,16 +130,16 @@ def compare_dataset_attr(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
         # Scalar value
         if issubclass(val_1.dtype.type, np.number) and issubclass(val_2.dtype.type, np.number):
             # numerical array
-            rtnval = np.array_equal(val_1, val_2, equal_nan=True)
-            if not rtnval:
+            return_val = np.array_equal(val_1, val_2, equal_nan=True)
+            if not return_val:
                 print('    - numerical scalar. Failed to pass np.array_equal()')
-            return rtnval
+            return return_val
 
         # Not a numerical array
-        rtnval = np.array_equal(val_1, val_2)
-        if not rtnval:
+        return_val = np.array_equal(val_1, val_2)
+        if not return_val:
             print('    - non-numerical scalar. Failed to pass np.array_equal()')
-        return rtnval
+        return return_val
 
     if len(shape_val_1)==1 and len(shape_val_2)==1:
         # 1d vector
@@ -206,26 +206,26 @@ def compare_dataset_attr(hdf5_obj_1, hdf5_obj_2, str_key, is_attr=False):
 
         if issubclass(val_1.dtype.type, np.number) and issubclass(val_2.dtype.type, np.number):
             # val_1 and val_2 are numeric numpy array
-            rtnval = np.array_equal(val_1, val_2, equal_nan=True)
-            if not rtnval:
+            return_val = np.array_equal(val_1, val_2, equal_nan=True)
+            if not return_val:
                 print('    - Numerical array. Failed to pass np.array_equal()')
-            return rtnval
+            return return_val
 
         # All other cases, including the npy array with bytes
-        rtnval = np.array_equal(val_1, val_2)
-        if not rtnval:
+        return_val = np.array_equal(val_1, val_2)
+        if not return_val:
             print('    Non-numerical array. Failed to pass np.array_equal()')
-        return rtnval
+        return return_val
 
 
     if len(shape_val_1)>=2 and len(shape_val_2)>=2:
-        rtnval = np.allclose(val_1,
+        return_val = np.allclose(val_1,
                              val_2,
                              RTC_S1_PRODUCTS_ERROR_TOLERANCE,
                              equal_nan=True)
-        if not rtnval:
+        if not return_val:
             print(f'    {len(shape_val_1)}D raster array. Failed to pass np.allclose()')
-        return rtnval
+        return return_val
 
     # If the processing has reached here, that means
     # val_1 and val_2 cannot be compated due to their shape difference

--- a/src/rtc/runconfig.py
+++ b/src/rtc/runconfig.py
@@ -190,7 +190,8 @@ def runconfig_to_bursts(cfg: SimpleNamespace) -> list[Sentinel1BurstSlc]:
         for pol, i_subswath in pol_subswath_index_pairs:
 
             # loop over burst objs extracted from SAFE zip
-            for burst in load_bursts(safe_file, orbit_path, i_subswath, pol):
+            for burst in load_bursts(safe_file, orbit_path, i_subswath, pol,
+                                     flag_apply_eap=False):
                 # get burst ID
                 burst_id = burst.burst_id
 


### PR DESCRIPTION
This is to turn off the EAP capability on `s1-reader` to avoid AUX_CAL loading.
Just a line of change, but we need `s1_orbit.get_orbit_file_from_list()`, in order to run this without error. The most recent version of `s1-reader` is missing this function. I've suggested to revive the functionality in the PR [here](https://github.com/opera-adt/s1-reader/pull/79)