### PR TITLE
Flexibility to Docker

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -46,4 +46,4 @@ RUN echo "Installing OPERA s1-reader and RTC" &&\
 
 WORKDIR /home/rtc_user/scratch
 
-ENTRYPOINT ["conda", "run", "--no-capture-output", "-n", "RTC","rtc_s1.py"]
+ENTRYPOINT ["conda", "run", "--no-capture-output", "-n", "RTC"]

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -17,7 +17,7 @@ USER rtc_user
 ENV CONDA_PREFIX=/home/rtc_user/miniconda3
 
 
-#Install conda and 
+#Install conda and RTC
 WORKDIR /home/rtc_user
 RUN curl -sSL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh &&\
     bash miniconda.sh -b -p ${CONDA_PREFIX} &&\
@@ -33,10 +33,10 @@ SHELL ["conda", "run", "-n", "RTC", "/bin/bash", "-c"]
 
 RUN echo "Installing OPERA s1-reader and RTC" &&\
     cd $HOME/OPERA &&\
-    curl -sSL https://github.com/seongsujeong/s1-reader/archive/refs/tags/v0.1.4-beta.temp.zip -o s1_reader.zip &&\
+    curl -sSL https://github.com/opera-adt/s1-reader/archive/refs/tags/v0.1.3.zip -o s1_reader.zip &&\
     unzip s1_reader.zip &&\
-    chmod -R 755 s1-reader-0.1.4-beta.temp &&\
-    ln -s s1-reader-0.1.4-beta.temp s1-reader &&\
+    chmod -R 755 s1-reader-0.1.3 &&\
+    ln -s s1-reader-0.1.3 s1-reader &&\
     rm s1_reader.zip &&\
     python -m pip install ./s1-reader &&\
     python -m pip install ./RTC &&\

--- a/app/rtc_compare.py
+++ b/app/rtc_compare.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 '''
 Compare two RTC products (in HDF5) if they are equivalent.
 Part of the codes are copied from PROTEUS SAS

--- a/build_docker_image.sh
+++ b/build_docker_image.sh
@@ -2,7 +2,7 @@
 
 REPO=opera
 IMAGE=rtc
-TAG=interface_0.1
+TAG=0.2_beta
 
 echo "IMAGE is $REPO/$IMAGE:$TAG"
 
@@ -19,7 +19,7 @@ docker build --rm --force-rm --network host -t $REPO/$IMAGE:$TAG -f Docker/Docke
 #docker run --rm -u "$(id -u):$(id -g)" -v "$PWD:/mnt" -w /mnt -it --network host "${IMAGE}:$t" pytest /mnt/tests/
 
 # create image tar
-docker save $REPO/$IMAGE:$TAG > Docker/dockerimg_rtc_interface_0.1.tar
+docker save $REPO/$IMAGE:$TAG > Docker/dockerimg_rtc_beta_0.2.tar
 
 # remove image
 docker image rm $REPO/$IMAGE:$TAG

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     include_package_data = True,
     package_data = package_data_dict,
     classifiers = ['Programming Language :: Python',],
-    scripts = ['app/rtc_s1.py'],
+    scripts = ['app/rtc_s1.py', 'app/rtc_validate.py'],
     install_requires = ['argparse', 'numpy', 'yamale',
                        'scipy', 'pytest', 'requests',
                        'pyproj', 'shapely'],


### PR DESCRIPTION
This PR will modify Docker image to make it easy to run not only `rtc_s1.py` but also the validation script.
The previous version of the Dockerfile can run the validation script, but we need to override the entry point using `--entrypoint` in `docker run`.

Please also note that the docker usage needs to be updated accordingly. We have been omitting the main code name `rtc_s1.py`, which needs to be provided after this change. Providing `rtc_compare.py`, followed by the path to the products (in the context of Docker container) will run the validation script.