### PR TITLE
Remove checks that force mosaic and bursts to have the same EPSG code and pixel spacing

### DIFF
--- a/app/rtc_s1.py
+++ b/app/rtc_s1.py
@@ -55,16 +55,32 @@ def _update_mosaic_boundaries(mosaic_geogrid_dict, geogrid):
         mosaic_geogrid_dict['yf'] = yf
     if 'dx' not in mosaic_geogrid_dict.keys():
         mosaic_geogrid_dict['dx'] = geogrid.spacing_x
-    else:
-        assert(mosaic_geogrid_dict['dx'] == geogrid.spacing_x)
+    # else:
+    #     assert(mosaic_geogrid_dict['dx'] == geogrid.spacing_x)
     if 'dy' not in mosaic_geogrid_dict.keys():
         mosaic_geogrid_dict['dy'] = geogrid.spacing_y
-    else:
-        assert(mosaic_geogrid_dict['dy'] == geogrid.spacing_y)
+    # else:
+    #     assert(mosaic_geogrid_dict['dy'] == geogrid.spacing_y)
+
+
+
+
+
+
+
+    # TODO fix this. The mosaic EPSG should not come from the
+    # first burst
     if 'epsg' not in mosaic_geogrid_dict.keys():
         mosaic_geogrid_dict['epsg'] = geogrid.epsg
-    else:
-        assert(mosaic_geogrid_dict['epsg'] == geogrid.epsg)
+    # else:
+    #     assert(mosaic_geogrid_dict['epsg'] == geogrid.epsg)
+
+
+
+
+
+
+
 
 
 def _separate_pol_channels(multi_band_file, output_file_list, logger,

--- a/app/rtc_s1.py
+++ b/app/rtc_s1.py
@@ -55,12 +55,8 @@ def _update_mosaic_boundaries(mosaic_geogrid_dict, geogrid):
         mosaic_geogrid_dict['yf'] = yf
     if 'dx' not in mosaic_geogrid_dict.keys():
         mosaic_geogrid_dict['dx'] = geogrid.spacing_x
-    # else:
-    #     assert(mosaic_geogrid_dict['dx'] == geogrid.spacing_x)
     if 'dy' not in mosaic_geogrid_dict.keys():
         mosaic_geogrid_dict['dy'] = geogrid.spacing_y
-    # else:
-    #     assert(mosaic_geogrid_dict['dy'] == geogrid.spacing_y)
 
 
 
@@ -72,8 +68,6 @@ def _update_mosaic_boundaries(mosaic_geogrid_dict, geogrid):
     # first burst
     if 'epsg' not in mosaic_geogrid_dict.keys():
         mosaic_geogrid_dict['epsg'] = geogrid.epsg
-    # else:
-    #     assert(mosaic_geogrid_dict['epsg'] == geogrid.epsg)
 
 
 


### PR DESCRIPTION
This PR removes the checks that force mosaic and bursts to have the same EPSG code and pixel spacing. With the added support for the burst DB, the burst grids can have their own EPSG codes that can differ from the mosaic EPSG code. This PR removes the check that forces the mosaic and bursts to have the same EPSG code. This PR also remove the checks for the pixel spacing that are no longer required. The mosaicking code will handle the reprojection of the input bursts whenever needed.