### PR TITLE
Workflow fix

### DIFF
--- a/src/rtc/rtc_s1.py
+++ b/src/rtc/rtc_s1.py
@@ -488,11 +488,11 @@ def run_parallel(cfg: RunConfig, logfile_path, flag_logger_full_format):
 
     if num_workers == 0:
         # Read system variable OMP_NUM_THREADS
-        num_workers = int(os.getenv('OMP_NUM_THREADS'))
+        num_workers = os.getenv('OMP_NUM_THREADS')
         if not num_workers:
             # Otherwise, read it from os.cpu_count()
             num_workers = os.cpu_count()
-    num_workers = min(num_workers, len(burst_runconfig_list))
+    num_workers = min(int(num_workers), len(burst_runconfig_list))
 
     # Execute the single burst processes using multiprocessing
     with multiprocessing.Pool(num_workers) as p:
@@ -664,18 +664,19 @@ def run_parallel(cfg: RunConfig, logfile_path, flag_logger_full_format):
 
             if flag_layover_shadow_mask_is_temporary:
                 temp_files_list.append(layover_shadow_mask_file)
+                layover_shadow_mask_file = None
             else:
                 output_file_list.append(layover_shadow_mask_file)
                 logger.info(f'file saved: {layover_shadow_mask_file}')
 
-            # Take the layover shadow mask from HDF5 file if not exists
-            if save_secondary_layers_as_hdf5:
-                layover_shadow_mask_file = (f'NETCDF:{burst_hdf5_in_output}:'
-                                            '/science/SENTINEL1/RTC/grids/'
-                                            'frequencyA/layoverShadowMask')
+                # Take the layover shadow mask from HDF5 file if not exists
+                if save_secondary_layers_as_hdf5:
+                    layover_shadow_mask_file = (f'NETCDF:{burst_hdf5_in_output}:'
+                                                '/science/SENTINEL1/RTC/grids/'
+                                                'frequencyA/layoverShadowMask')
 
-            output_metadata_dict['layover_shadow_mask'][1].append(
-                layover_shadow_mask_file)
+                output_metadata_dict['layover_shadow_mask'][1].append(
+                    layover_shadow_mask_file)
 
         else:
             layover_shadow_mask_file = None

--- a/src/rtc/rtc_s1.py
+++ b/src/rtc/rtc_s1.py
@@ -678,6 +678,9 @@ def run_parallel(cfg: RunConfig, logfile_path, flag_logger_full_format):
                 output_metadata_dict['layover_shadow_mask'][1].append(
                     layover_shadow_mask_file)
 
+            if not save_layover_shadow_mask:
+                layover_shadow_mask_file = None
+
         else:
             layover_shadow_mask_file = None
 

--- a/src/rtc/rtc_s1_single_job.py
+++ b/src/rtc/rtc_s1_single_job.py
@@ -791,11 +791,12 @@ def run_single_job(cfg: RunConfig):
 
             if flag_layover_shadow_mask_is_temporary:
                 temp_files_list.append(layover_shadow_mask_file)
+                layover_shadow_mask_file = None
             else:
                 output_file_list.append(layover_shadow_mask_file)
                 logger.info(f'file saved: {layover_shadow_mask_file}')
-            output_metadata_dict['layover_shadow_mask'][1].append(
-                layover_shadow_mask_file)
+                output_metadata_dict['layover_shadow_mask'][1].append(
+                    layover_shadow_mask_file)
 
             if apply_shadow_masking:
                 geocode_new_isce3_kwargs['input_slantrange_layover_shadow_mask_raster'] = \

--- a/src/rtc/rtc_s1_single_job.py
+++ b/src/rtc/rtc_s1_single_job.py
@@ -791,12 +791,14 @@ def run_single_job(cfg: RunConfig):
 
             if flag_layover_shadow_mask_is_temporary:
                 temp_files_list.append(layover_shadow_mask_file)
-                layover_shadow_mask_file = None
             else:
                 output_file_list.append(layover_shadow_mask_file)
                 logger.info(f'file saved: {layover_shadow_mask_file}')
                 output_metadata_dict['layover_shadow_mask'][1].append(
                     layover_shadow_mask_file)
+
+            if not save_layover_shadow_mask:
+                layover_shadow_mask_file = None
 
             if apply_shadow_masking:
                 geocode_new_isce3_kwargs['input_slantrange_layover_shadow_mask_raster'] = \


### PR DESCRIPTION
This PR fixes the issues below which were discovered further test of the workflow:
- Automatic `num_workers` determination attempts to try `int(None)` when `OMP_NUM_THREADS` is not defined in the environment
- Layover shadow mask gets saved regardless of the flag `save_layover_shadow_mask` in runconfig when `apply_shadow_masking` is turned on