### PR TITLE
take care of error when `--log` is not provided in CLI

### DIFF
--- a/src/rtc/core.py
+++ b/src/rtc/core.py
@@ -167,8 +167,11 @@ def create_logger(log_file, full_log_formatting=None):
        logger : logging.Logger
               Logger object
     """
+    if log_file:
+        logfile_directory = os.path.dirname(log_file)
+    else:
+        logfile_directory = None
 
-    logfile_directory = os.path.dirname(log_file)
     if logfile_directory:
         os.makedirs(logfile_directory, exist_ok=True)
     # create logger

--- a/src/rtc/rtc_s1.py
+++ b/src/rtc/rtc_s1.py
@@ -79,8 +79,12 @@ def split_runconfig(cfg_in,
             os.path.join(cfg_in.groups.product_group.scratch_path,
                          f'{os.path.basename(child_output_dir)}_child_scratch')
 
-    # determine the output directory for child process
-    basename_logfile = os.path.basename(parent_logfile_path)
+    if parent_logfile_path:
+        # determine the output directory for child process
+        basename_logfile = os.path.basename(parent_logfile_path)
+    else:
+        basename_logfile = None
+
     for burst_id in list_burst_id:
         path_temp_runconfig = os.path.join(cfg_in.scratch_path,
                                            f'burst_runconfig_{burst_id}.yaml')


### PR DESCRIPTION
This PR fixed the error when `--log` was not provided in CLI. The error was coming from the previous PR #39, when it was attempting to create the directory even when the user is not saving the log file into file system.