### PR TITLE
More changes after Cal/Val Release

### DIFF
--- a/src/rtc/defaults/rtc_s1.yaml
+++ b/src/rtc/defaults/rtc_s1.yaml
@@ -151,6 +151,9 @@ runconfig:
                 # RTC DEM upsampling
                 dem_upsampling: 2
 
+                # RTC area factor mode
+                area_factor_mode: projection_angle
+
             # OPTIONAL - to provide the number of processes when processing the bursts in parallel
             # "0" means that the number will be automatically decided based on
             # the number of cores, `OMP_NUM_THREADS` in environment setting,

--- a/src/rtc/defaults/rtc_s1.yaml
+++ b/src/rtc/defaults/rtc_s1.yaml
@@ -151,8 +151,8 @@ runconfig:
                 # RTC DEM upsampling
                 dem_upsampling: 2
 
-                # RTC area factor mode
-                area_factor_mode: auto
+                # RTC area beta mode
+                area_beta_mode: auto
 
             # OPTIONAL - to provide the number of processes when processing the bursts in parallel
             # "0" means that the number will be automatically decided based on

--- a/src/rtc/defaults/rtc_s1.yaml
+++ b/src/rtc/defaults/rtc_s1.yaml
@@ -163,7 +163,7 @@ runconfig:
             # Geocoding options
             geocoding:
 
-                # Apply RSLC metadata valid-samples sub-swath masking
+                # Apply valid-samples sub-swath masking
                 apply_valid_samples_sub_swath_masking: True
 
                 # Apply shadow masking

--- a/src/rtc/defaults/rtc_s1.yaml
+++ b/src/rtc/defaults/rtc_s1.yaml
@@ -152,7 +152,7 @@ runconfig:
                 dem_upsampling: 2
 
                 # RTC area factor mode
-                area_factor_mode: projection_angle
+                area_factor_mode: auto
 
             # OPTIONAL - to provide the number of processes when processing the bursts in parallel
             # "0" means that the number will be automatically decided based on

--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -698,6 +698,7 @@ def get_metadata_dict(product_id: str,
          ' applied']
 
     # Add geocoding algorithm reference depending on the algorithm applied
+    # TODO: add references to the other geocoding algorithms
     if cfg_in.groups.processing.geocoding.algorithm_type == 'area_projection':
         url_geocoding_algorithm_document = \
                 ('Gustavo H. X. Shiroma, Marco Lavalle, and Sean M. Buckley,'

--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -346,7 +346,8 @@ def get_metadata_dict(product_id: str,
         'identification/lookDirection':
             ['look_direction',
              ALL_PRODUCTS,
-             'right', 'Look direction can be left or right'],
+             'right',
+             'Look direction can be left or right'],
         'identification/orbitPassDirection':
             ['orbit_pass_direction',
              ALL_PRODUCTS,
@@ -377,7 +378,10 @@ def get_metadata_dict(product_id: str,
              ' instrument data in radar coordinates system; and L2:'
              ' Processed instrument data in geocoded coordinates system'],
         'identification/productID':
-            ['product_id', product_id, 'Product identifier'],
+            ['product_id',
+             ALL_PRODUCTS,
+             product_id,
+             'Product identifier'],
 
         'identification/processingType':
             ['processing_type',
@@ -418,8 +422,6 @@ def get_metadata_dict(product_id: str,
         # 'metadata/sourceData/radarBand':  # 1.6.4
         #    ['radar_band', 'C', 'Acquired frequency band'],
 
-        # TODO: add range bandwidth
-
         # TODO: review, should it be
         # burst_in.burst_misc_metadata.processing_info_dict["organisation"]?
         'metadata/sourceData/institution':
@@ -434,6 +436,12 @@ def get_metadata_dict(product_id: str,
               f'site: \"{burst_in.burst_misc_metadata.processing_info_dict["site"]}\", '
               f'country: \"{burst_in.burst_misc_metadata.processing_info_dict["country"]}\"'),
              'Source data processing center'],
+
+        'metadata/sourceData/rangeBandwidth':
+            ['source_data_range_bandwidth',
+             NO_STATIC_LAYERS,
+             str(burst_in.range_bandwidth),
+             'Processed range bandwidth in Hz'],
 
         # populate source data processingDateTime with from processing_info
         # "stop" (SLC Post processing date time)

--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -275,7 +275,7 @@ def get_metadata_dict(product_id: str,
 
     # Constants to represent flag (*1) above
     ALL_PRODUCTS = True
-    NO_STATIC_LAYERS = False
+    STANDARD_RTC_S1_ONLY = False
 
     metadata_dict = {
         'identification/absoluteOrbitNumber':
@@ -359,7 +359,7 @@ def get_metadata_dict(product_id: str,
         #  are nominal or urgent'],
         'identification/diagnosticModeFlag':
             ['diagnostic_mode_flag',
-             NO_STATIC_LAYERS,
+             STANDARD_RTC_S1_ONLY,
              False,
              'Indicates if the radar mode is a diagnostic mode or not: True or'
              ' False'],
@@ -439,7 +439,7 @@ def get_metadata_dict(product_id: str,
 
         'metadata/sourceData/rangeBandwidth':
             ['source_data_range_bandwidth',
-             NO_STATIC_LAYERS,
+             STANDARD_RTC_S1_ONLY,
              str(burst_in.range_bandwidth),
              'Processed range bandwidth in Hz'],
 
@@ -462,12 +462,12 @@ def get_metadata_dict(product_id: str,
         
         'metadata/sourceData/azimuthLooks':  # 1.6.6
             [None,
-             NO_STATIC_LAYERS,
+             STANDARD_RTC_S1_ONLY,
              burst_in.burst_misc_metadata.azimuth_looks,
              'Azimuth number of looks'],
         'metadata/sourceData/slantRangeLooks':  # 1.6.6
             [None,
-             NO_STATIC_LAYERS,
+             STANDARD_RTC_S1_ONLY,
              burst_in.burst_misc_metadata.slant_range_looks,
              'Slant range number of looks'],
 
@@ -478,7 +478,7 @@ def get_metadata_dict(product_id: str,
              'Product level of the source data'],
         'metadata/sourceData/centerFrequency':
             ['center_frequency',
-             NO_STATIC_LAYERS,
+             STANDARD_RTC_S1_ONLY,
              burst_in.radar_center_frequency,
              'Center frequency of the processed image in Hz'],
         # 'metadata/sourceData/geometry':  # 1.6.7
@@ -507,12 +507,12 @@ def get_metadata_dict(product_id: str,
 
         'metadata/sourceData/nearRangeIncidenceAngle':  # 1.6.7
             [None,
-             NO_STATIC_LAYERS,
+             STANDARD_RTC_S1_ONLY,
              burst_in.burst_misc_metadata.inc_angle_near_range,
              'Near range incidence angle in meters'],
         'metadata/sourceData/farRangeIncidenceAngle':  # 1.6.7
             [None,
-             NO_STATIC_LAYERS,
+             STANDARD_RTC_S1_ONLY,
              burst_in.burst_misc_metadata.inc_angle_far_range,
              'Far range incidence angle in meters'],
         # Source for the max. NESZ:
@@ -520,7 +520,7 @@ def get_metadata_dict(product_id: str,
         #  sentinel-1-sar/acquisition-modes/interferometric-wide-swath)
         'metadata/sourceData/maxNoiseEquivalentSigmaZero':  # 1.6.9
             [None,
-             NO_STATIC_LAYERS,
+             STANDARD_RTC_S1_ONLY,
              -22,
              'Maximum Noise equivalent sigma0 in dB'],
 
@@ -536,34 +536,34 @@ def get_metadata_dict(product_id: str,
         #     'URL to access the product data'],
         'metadata/processingInformation/parameters/postProcessingFilteringApplied':  # 1.7.4
             ['post_processing_filtering_applied',
-             NO_STATIC_LAYERS,
+             STANDARD_RTC_S1_ONLY,
              False,
              'Flag to indicate if post-processing filtering has been applied'],
 
         # 3.3
         'metadata/processingInformation/parameters/noiseCorrectionApplied':
             ['noise_correction_applied',
-             NO_STATIC_LAYERS,
+             STANDARD_RTC_S1_ONLY,
              cfg_in.groups.processing.apply_thermal_noise_correction,
              'Flag to indicate if noise removal has been applied'],
         'metadata/processingInformation/parameters/radiometricTerrainCorrectionApplied':
             ['rtc_applied',
-             NO_STATIC_LAYERS,
+             STANDARD_RTC_S1_ONLY,
              cfg_in.groups.processing.apply_rtc,
              'Flag to indicate if radiometric terrain correction (RTC) has been applied'],
         'metadata/processingInformation/parameters/dryTroposphericGeolocationCorrectionApplied':
             ['dry_tropospheric_geolocation_correction_applied',
-             NO_STATIC_LAYERS,
+             STANDARD_RTC_S1_ONLY,
              cfg_in.groups.processing.apply_dry_tropospheric_delay_correction,
              'Flag to indicate if the dry tropospheric correction has been applied'],
         'metadata/processingInformation/parameters/wetTroposphericGeolocationCorrectionApplied':
             ['wet_tropospheric_geolocation_correction_applied',
-             NO_STATIC_LAYERS,
+             STANDARD_RTC_S1_ONLY,
              False,
              'Flag to indicate if the wet tropospheric correction has been applied'],
         'metadata/processingInformation/parameters/bistaticDelayCorrectionApplied':
             ['bistatic_delay_correction_applied',
-             NO_STATIC_LAYERS,
+             STANDARD_RTC_S1_ONLY,
              cfg_in.groups.processing.apply_bistatic_delay_correction,
              'Flag to indicate if the bistatic delay correction has been applied'],
 
@@ -667,7 +667,7 @@ def get_metadata_dict(product_id: str,
     metadata_dict['metadata/processingInformation/algorithms/'
                   'noiseCorrectionAlgorithmReference'] =\
         ['noise_removal_algorithm_reference',
-         NO_STATIC_LAYERS,
+         STANDARD_RTC_S1_ONLY,
          noise_removal_algorithm_reference,
          'A reference to the noise removal algorithm applied']
 

--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -728,7 +728,7 @@ def get_metadata_dict(product_id: str,
 
         metadata_dict['identification/boundingPolygon'] = \
             ['bounding_polygon',
-             ALL_PRODUCTS,
+             STANDARD_RTC_S1_ONLY,
              get_polygon_wkt(burst_in),
              'OGR compatible WKT representation of the product'
              ' bounding polygon']
@@ -736,23 +736,29 @@ def get_metadata_dict(product_id: str,
         # Attribute `epsg` for HDF5 dataset /identification/boundingPolygon
         metadata_dict['identification/boundingPolygon[epsg]'] = \
             ['bouding_polygon_epsg_code',
-             ALL_PRODUCTS,
+             STANDARD_RTC_S1_ONLY,
              '4326',
              'Bounding polygon EPSG code']
 
-        # xy_bounding_box = [
-        #    xmin_geogrid,
-        #    ymax_geogrid + length_geogrid * spacing_y,
-        #    xmin_geogrid + width_geogrid * spacing_x,
-        #    ymax_geogrid
-        # ]
+        xy_bounding_box = [
+           xmin_geogrid,
+           ymax_geogrid + length_geogrid * spacing_y,
+           xmin_geogrid + width_geogrid * spacing_x,
+           ymax_geogrid
+        ]
 
-        # metadata_dict['identification/boundingBox'] = \
-        #    ['bounding_box',
-        #     ALL_PRODUCTS,
-        #     np.array(xy_bounding_box),  # 1.7.5
-        #     'Bounding box of the product, in order of xmin, ymin, xmax, ymax']
+        metadata_dict['identification/boundingBox'] = \
+            [None,
+             STANDARD_RTC_S1_ONLY,
+             np.array(xy_bounding_box),  # 1.7.5
+             'Bounding box of the product, in order of xmin, ymin, xmax, ymax']
 
+        # Attribute `epsg` for HDF5 dataset /identification/boundingBox
+        metadata_dict['identification/boundingBox[epsg]'] = \
+            [None,
+             STANDARD_RTC_S1_ONLY,
+             str(epsg_geogrid),
+             'Bounding box EPSG code']
 
         metadata_dict['identification/burstID'] = \
             ['burst_id',

--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -215,10 +215,10 @@ def get_metadata_dict(product_id: str,
 
     Returns
     -------
-    metadata_dict : dict
+    _ : dict
         Metadata dict organized as follows:
         - Dictionary item key: HDF5 dataset key;
-        - Dictionary item value: list of 
+        - Dictionary item value: list of
             [GeoTIFF metadata key,
              metadata value,
              metadata description]
@@ -265,69 +265,113 @@ def get_metadata_dict(product_id: str,
 
     # Manifests the field names, corresponding values from RTC workflow, and
     # the description. To extend this, add the lines with the format below:
-    # 'field_name': [corresponding_variables_in_workflow, description]
+    # 'field_name': [
+    #     GeoTIFF metadata field,
+    #     Flag indicating whether the field is present in RTC-S1 Static Layer
+    #     products (*1),
+    #     Metadata field value, 
+    #     Metadata field description
+    # ]
+
+    # Constants to represent flag (*1) above
+    ALL_PRODUCTS = True
+    NO_STATIC_LAYERS = False
+
     metadata_dict = {
         'identification/absoluteOrbitNumber':
-            ['absolute_orbit_number', burst_in.abs_orbit_number,
+            ['absolute_orbit_number',
+             ALL_PRODUCTS,
+             burst_in.abs_orbit_number,
              'Absolute orbit number'],
         # NOTE: The field below does not exist on opera_rtc.xml
         # 'identification/relativeOrbitNumber':
         #   [int(burst_in.burst_id[1:4]), 'Relative orbit number'],
         'identification/trackNumber':
-            ['track_number', burst_in.burst_id.track_number,
+            ['track_number',
+             ALL_PRODUCTS,
+             burst_in.burst_id.track_number,
              'Track number'],
         # 'identification/missionId':
         #    [mission_id, 'Mission identifier'],
         'identification/platform':
-            ['platform', platform_id, 'Platform name'],
+            ['platform',
+             ALL_PRODUCTS,
+             platform_id,
+             'Platform name'],
         # Instrument name mentioned at:
         # https://sentinel.esa.int/documents/247904/349449/s1_sp-1322_1.pdf
         'identification/instrumentName':
-            ['instrument_name', f'{platform_id} CSAR',
+            ['instrument_name',
+             ALL_PRODUCTS,
+             f'{platform_id} CSAR',
              'Name of the instrument used to'
              ' collect the remote sensing data provided in this product'],
         'identification/productType':
-            ['product_type', 'RTC-S1', 'Product type'],
+            ['product_type',
+             ALL_PRODUCTS,
+             'RTC-S1',
+             'Product type'],
         'identification/project':
-            ['project', 'OPERA', 'Project name'],
+            ['project',
+             ALL_PRODUCTS,
+             'OPERA',
+             'Project name'],
         'identification/institution':
-            ['institution', 'NASA JPL',
+            ['institution',
+             ALL_PRODUCTS,
+             'NASA JPL',
              'Institution that created this product'],
         'identification/productVersion':
-            ['product_version', product_version,
+            ['product_version',
+             ALL_PRODUCTS,
+             product_version,
              'Product version which represents the structure of the product'
              ' and the science content governed by the algorithm, input data,'
              ' and processing parameter'],
         'identification/productSpecificationVersion':
-            ['product_specification_version', PRODUCT_SPECIFICATION_VERSION,
+            ['product_specification_version',
+             ALL_PRODUCTS,
+             PRODUCT_SPECIFICATION_VERSION,
              'Product specification version which represents the schema of'
              ' this product'],
         'identification/acquisitionMode':
-            ['acquisition_mode', 'Interferometric Wide (IW)',
+            ['acquisition_mode',
+             ALL_PRODUCTS,
+             'Interferometric Wide (IW)',
              'Acquisition mode'],
         # 'identification/CARDProductType':
         #    ['card_product_type', 'Normalised Radar Backscatter',
         #     'CARD Product type'], # 1.3
 
         'identification/lookDirection':
-            ['look_direction', 'right', 'Look direction can be left or right'],
+            ['look_direction',
+             ALL_PRODUCTS,
+             'right', 'Look direction can be left or right'],
         'identification/orbitPassDirection':
-            ['orbit_pass_direction', burst_in.orbit_direction.lower(),
+            ['orbit_pass_direction',
+             ALL_PRODUCTS,
+             burst_in.orbit_direction.lower(),
              'Orbit direction can be ascending or descending'],
         # 'identification/isUrgentObservation':
         #     ['is_urgent_observation', False,
         #      'List of booleans indicating if datatakes
         #  are nominal or urgent'],
         'identification/diagnosticModeFlag':
-            ['diagnostic_mode_flag', False,
+            ['diagnostic_mode_flag',
+             NO_STATIC_LAYERS,
+             False,
              'Indicates if the radar mode is a diagnostic mode or not: True or'
              ' False'],
         'identification/isGeocoded':
-            [None, True,
+            [None,
+             ALL_PRODUCTS,
+             True,
              'Flag to indicate whether the primary product data is in radar'
              ' geometry ("False") or map geometry ("True")'],
         'identification/productLevel':
-            ['product_level', 'L2',
+            ['product_level',
+             ALL_PRODUCTS,
+             'L2',
              'Product level. L0A: Unprocessed instrument data; L0B:'
              ' Reformatted, unprocessed instrument data; L1: Processed'
              ' instrument data in radar coordinates system; and L2:'
@@ -336,14 +380,21 @@ def get_metadata_dict(product_id: str,
             ['product_id', product_id, 'Product identifier'],
 
         'identification/processingType':
-            ['processing_type', processing_type,
-             'NOMINAL (or) URGENT (or) CUSTOM (or) UNDEFINED'],
+            ['processing_type',
+             ALL_PRODUCTS,
+             processing_type,
+             'Processing type: "NOMINAL", "STATIC_LAYERS", "URGENT",'
+             ' "CUSTOM", or "UNDEFINED"'],
         'identification/processingDateTime':
             ['processing_date_time',
+             ALL_PRODUCTS,
              processing_datetime.strftime(DATE_TIME_METADATA_FORMAT),
              'Processing date and time in the format YYYY-MM-DDThh:mm:ss.sZ'],
         'identification/radarBand':  # 1.6.4
-            ['radar_band', 'C', 'Acquired frequency band'],
+            ['radar_band',
+             ALL_PRODUCTS,
+             'C',
+             'Acquired frequency band'],
         # 'metadata/processingCenter': # 1.7.1
         #     ['source_data_processing_center',
         #      (f'organization: "Jet Propulsion Laboratory", '
@@ -355,7 +406,9 @@ def get_metadata_dict(product_id: str,
         #    ["https://ceos.org/ard/files/PFS/NRB/v5.5/CARD4L-PFS_NRB_v5.5.pdf",
         #     'Product version'],
         'metadata/sourceData/numberOfAcquisitions':  # 1.6.4
-            ['source_data_number_of_acquisitions', 1,
+            ['source_data_number_of_acquisitions',
+             ALL_PRODUCTS,
+             1,
              'Number of source data acquisitions'],
         # TODO Review: should we expose this parameter in the runconfig?
         # 'metadata/sourceData/dataAccess':
@@ -370,10 +423,13 @@ def get_metadata_dict(product_id: str,
         # TODO: review, should it be
         # burst_in.burst_misc_metadata.processing_info_dict["organisation"]?
         'metadata/sourceData/institution':
-            ['source_data_institution', 'ESA',
+            ['source_data_institution',
+             ALL_PRODUCTS,
+             'ESA',
              'Institution that created the source data product'],
         'metadata/sourceData/processingCenter':  # 1.6.6
             ['source_data_processing_center',
+             ALL_PRODUCTS,
              (f'organization: \"{burst_in.burst_misc_metadata.processing_info_dict["organisation"]}\", '
               f'site: \"{burst_in.burst_misc_metadata.processing_info_dict["site"]}\", '
               f'country: \"{burst_in.burst_misc_metadata.processing_info_dict["country"]}\"'),
@@ -383,6 +439,7 @@ def get_metadata_dict(product_id: str,
         # "stop" (SLC Post processing date time)
         'metadata/sourceData/processingDateTime':  # 1.6.6
             ['source_data_processing_date_time',
+             ALL_PRODUCTS,
              burst_in.burst_misc_metadata.processing_info_dict['stop'],
              'Processing UTC date and time of the source data product (SLC'
              ' post processing date time) in the format'
@@ -390,25 +447,31 @@ def get_metadata_dict(product_id: str,
 
         'metadata/sourceData/softwareVersion':  # 1.6.6
             ['source_data_software_version',
+             ALL_PRODUCTS,
              str(burst_in.ipf_version),
              'Version of the software used to create the source data'
              ' (IPF version)'],
         
         'metadata/sourceData/azimuthLooks':  # 1.6.6
             [None,
+             NO_STATIC_LAYERS,
              burst_in.burst_misc_metadata.azimuth_looks,
              'Azimuth number of looks'],
         'metadata/sourceData/slantRangeLooks':  # 1.6.6
             [None,
+             NO_STATIC_LAYERS,
              burst_in.burst_misc_metadata.slant_range_looks,
              'Slant range number of looks'],
 
         'metadata/sourceData/productLevel':  # 1.6.6
             ['source_data_product_level',
+             ALL_PRODUCTS,
              'L1',
              'Product level of the source data'],
         'metadata/sourceData/centerFrequency':
-            ['center_frequency', burst_in.radar_center_frequency,
+            ['center_frequency',
+             NO_STATIC_LAYERS,
+             burst_in.radar_center_frequency,
              'Center frequency of the processed image in Hz'],
         # 'metadata/sourceData/geometry':  # 1.6.7
         #     ['source_data_geometry',
@@ -416,10 +479,12 @@ def get_metadata_dict(product_id: str,
         #     'Geometry of the source data'],
         'metadata/sourceData/zeroDopplerTimeSpacing':  # 1.6.7
             ['source_data_zero_doppler_time_spacing',
+             ALL_PRODUCTS,
              burst_in.azimuth_time_interval,
              'Azimuth spacing of the source data in seconds'], 
         'metadata/sourceData/slantRangeSpacing':  # 1.6.7
             ['source_data_slant_range_spacing',
+             ALL_PRODUCTS,
              burst_in.range_pixel_spacing,
              'Slant range spacing of the source data in meters'],
 
@@ -434,10 +499,12 @@ def get_metadata_dict(product_id: str,
 
         'metadata/sourceData/nearRangeIncidenceAngle':  # 1.6.7
             [None,
+             NO_STATIC_LAYERS,
              burst_in.burst_misc_metadata.inc_angle_near_range,
              'Near range incidence angle in meters'],
         'metadata/sourceData/farRangeIncidenceAngle':  # 1.6.7
             [None,
+             NO_STATIC_LAYERS,
              burst_in.burst_misc_metadata.inc_angle_far_range,
              'Far range incidence angle in meters'],
         # Source for the max. NESZ:
@@ -445,11 +512,15 @@ def get_metadata_dict(product_id: str,
         #  sentinel-1-sar/acquisition-modes/interferometric-wide-swath)
         'metadata/sourceData/maxNoiseEquivalentSigmaZero':  # 1.6.9
             [None,
+             NO_STATIC_LAYERS,
              -22,
              'Maximum Noise equivalent sigma0 in dB'],
 
         'metadata/processingInformation/algorithms/softwareVersion':
-            ['software_version', str(SOFTWARE_VERSION), 'Software version'],
+            ['software_version',
+             ALL_PRODUCTS,
+             str(SOFTWARE_VERSION),
+             'Software version'],
         # TODO Review: should we expose this parameter in the runconfig?
         # 'metadata/processingInformation/dataAccess':  # placeholder for 1.7.1
         #    ['product_data_access',
@@ -457,28 +528,34 @@ def get_metadata_dict(product_id: str,
         #     'URL to access the product data'],
         'metadata/processingInformation/parameters/postProcessingFilteringApplied':  # 1.7.4
             ['post_processing_filtering_applied',
+             NO_STATIC_LAYERS,
              False,
              'Flag to indicate if post-processing filtering has been applied'],
 
         # 3.3
         'metadata/processingInformation/parameters/noiseCorrectionApplied':
             ['noise_correction_applied',
+             NO_STATIC_LAYERS,
              cfg_in.groups.processing.apply_thermal_noise_correction,
              'Flag to indicate if noise removal has been applied'],
         'metadata/processingInformation/parameters/radiometricTerrainCorrectionApplied':
             ['rtc_applied',
+             NO_STATIC_LAYERS,
              cfg_in.groups.processing.apply_rtc,
              'Flag to indicate if radiometric terrain correction (RTC) has been applied'],
         'metadata/processingInformation/parameters/dryTroposphericGeolocationCorrectionApplied':
             ['dry_tropospheric_geolocation_correction_applied',
+             NO_STATIC_LAYERS,
              cfg_in.groups.processing.apply_dry_tropospheric_delay_correction,
              'Flag to indicate if the dry tropospheric correction has been applied'],
         'metadata/processingInformation/parameters/wetTroposphericGeolocationCorrectionApplied':
             ['wet_tropospheric_geolocation_correction_applied',
+             NO_STATIC_LAYERS,
              False,
              'Flag to indicate if the wet tropospheric correction has been applied'],
         'metadata/processingInformation/parameters/bistaticDelayCorrectionApplied':
             ['bistatic_delay_correction_applied',
+             NO_STATIC_LAYERS,
              cfg_in.groups.processing.apply_bistatic_delay_correction,
              'Flag to indicate if the bistatic delay correction has been applied'],
 
@@ -514,40 +591,58 @@ def get_metadata_dict(product_id: str,
 
         'metadata/processingInformation/algorithms/demInterpolation':
             ['dem_interpolation_algorithm',
+             ALL_PRODUCTS,
              cfg_in.groups.processing.dem_interpolation_method,
              'DEM interpolation method'],
         'metadata/processingInformation/algorithms/geocoding':
             ['geocoding_algorithm',
+             ALL_PRODUCTS,
              cfg_in.groups.processing.geocoding.algorithm_type,
              'Geocoding algorithm'],
         'metadata/processingInformation/algorithms/radiometricTerrainCorrection':
             ['radiometric_terrain_correction_algorithm',
+             ALL_PRODUCTS,
              cfg_in.groups.processing.rtc.algorithm_type,
              'Radiometric terrain correction (RTC) algorithm'],
         'metadata/processingInformation/algorithms/isce3Version':
-            ['isce3_version', isce3.__version__,
+            ['isce3_version',
+             ALL_PRODUCTS,
+             isce3.__version__,
              'Version of the ISCE3 framework used for processing'],
         # 'metadata/processingInformation/algorithms/RTCVersion':
         #     [str(SOFTWARE_VERSION),
         # 'RTC-S1 SAS version used for processing'],
         'metadata/processingInformation/algorithms/s1ReaderVersion':
-            ['s1_reader_version', release_version,
+            ['s1_reader_version',
+             ALL_PRODUCTS,
+             release_version,
              'Version of the OPERA s1-reader used for processing'],
 
         'metadata/processingInformation/inputs/l1SLCGranules':
-            ['l1_slc_granules', l1_slc_granules,
+            ['l1_slc_granules',
+             ALL_PRODUCTS,
+             l1_slc_granules,
              'List of input L1 SLC products used'],
         'metadata/processingInformation/inputs/orbitFiles':
-            ['orbit_files', orbit_files, 'List of input orbit files used'],
+            ['orbit_files',
+             ALL_PRODUCTS,
+             orbit_files,
+             'List of input orbit files used'],
         'metadata/processingInformation/inputs/annotationFiles':
-            ['annotation_files', [burst_in.burst_calibration.basename_cads,
-             burst_in.burst_noise.basename_nads],
+            ['annotation_files',
+             ALL_PRODUCTS,
+             [burst_in.burst_calibration.basename_cads,
+              burst_in.burst_noise.basename_nads],
              'List of input annotation files used'],
         'metadata/processingInformation/inputs/configFiles':
-            ['config_files', cfg_in.run_config_path,
+            ['config_files',
+             ALL_PRODUCTS,
+             cfg_in.run_config_path,
              'List of input config files used'],
         'metadata/processingInformation/inputs/demSource':
-            ['dem_source', dem_file_description,
+            ['dem_source',
+             ALL_PRODUCTS,
+             dem_file_description,
              'Description of the input digital elevation model (DEM)']
     }
 
@@ -564,6 +659,7 @@ def get_metadata_dict(product_id: str,
     metadata_dict['metadata/processingInformation/algorithms/'
                   'noiseCorrectionAlgorithmReference'] =\
         ['noise_removal_algorithm_reference',
+         NO_STATIC_LAYERS,
          noise_removal_algorithm_reference,
          'A reference to the noise removal algorithm applied']
 
@@ -589,6 +685,7 @@ def get_metadata_dict(product_id: str,
     metadata_dict['metadata/processingInformation/algorithms/'
                   'radiometricTerrainCorrectionAlgorithmReference'] =\
         ['rtc_algorithm_reference',
+         ALL_PRODUCTS,
          url_rtc_algorithm_document,
          'Reference to the radiometric terrain correction (RTC) algorithm'
          ' applied']
@@ -603,80 +700,117 @@ def get_metadata_dict(product_id: str,
                  ' Art no. 5222723, doi: 10.1109/TGRS.2022.3147472.')
         metadata_dict['metadata/processingInformation/algorithms/'
                       'geocodingAlgorithmReference'] =\
-            ['geocoding_algorithm_reference', url_geocoding_algorithm_document,
+            ['geocoding_algorithm_reference',
+             ALL_PRODUCTS,
+             url_geocoding_algorithm_document,
              'Reference to the geocoding algorithm applied']
 
-    if is_mosaic:
-        return metadata_dict
+    if not is_mosaic:
 
-    # Metadata only for for burst product
-    # Calculate bounding box
-    xmin_geogrid = cfg_in.geogrids[str(burst_in.burst_id)].start_x
-    ymax_geogrid = cfg_in.geogrids[str(burst_in.burst_id)].start_y
-    spacing_x = cfg_in.geogrids[str(burst_in.burst_id)].spacing_x
-    spacing_y = cfg_in.geogrids[str(burst_in.burst_id)].spacing_y
-    width_geogrid = cfg_in.geogrids[str(burst_in.burst_id)].width
-    length_geogrid = cfg_in.geogrids[str(burst_in.burst_id)].length
-    xy_bounding_box = [
-        xmin_geogrid,
-        ymax_geogrid + length_geogrid * spacing_y,
-        xmin_geogrid + width_geogrid * spacing_x,
-        ymax_geogrid
-    ]
-    metadata_dict['identification/boundingBox'] = \
-        ['bounding_box', np.array(xy_bounding_box),  # 1.7.5
-         'Bounding box of the product, in order of xmin, ymin, xmax, ymax']
+        # Metadata only for for burst product
+        # Calculate bounding box
+        xmin_geogrid = cfg_in.geogrids[str(burst_in.burst_id)].start_x
+        ymax_geogrid = cfg_in.geogrids[str(burst_in.burst_id)].start_y
+        spacing_x = cfg_in.geogrids[str(burst_in.burst_id)].spacing_x
+        spacing_y = cfg_in.geogrids[str(burst_in.burst_id)].spacing_y
+        width_geogrid = cfg_in.geogrids[str(burst_in.burst_id)].width
+        length_geogrid = cfg_in.geogrids[str(burst_in.burst_id)].length
+        xy_bounding_box = [
+            xmin_geogrid,
+            ymax_geogrid + length_geogrid * spacing_y,
+            xmin_geogrid + width_geogrid * spacing_x,
+            ymax_geogrid
+        ]
 
-    metadata_dict['identification/boundingPolygon'] = \
-        ['bounding_polygon', get_polygon_wkt(burst_in),
-         'OGR compatible WKT representation of the product bounding polygon'
-         ' bounding polygon']
+        # TODO: Update for static layers!!!
+        metadata_dict['identification/boundingBox'] = \
+            ['bounding_box',
+             ALL_PRODUCTS,
+             np.array(xy_bounding_box),  # 1.7.5
+             'Bounding box of the product, in order of xmin, ymin, xmax, ymax']
 
-    metadata_dict['identification/burstID'] = \
-        ['burst_id', str(burst_in.burst_id),
-         'Burst identification (burst ID)']
+        # TODO: Update for static layers!!!
+        metadata_dict['identification/boundingPolygon'] = \
+            ['bounding_polygon',
+             ALL_PRODUCTS,
+             get_polygon_wkt(burst_in),
+             'OGR compatible WKT representation of the product bounding polygon'
+             ' bounding polygon']
 
-    beam_id = burst_in.swath_name.upper()
-    metadata_dict['identification/beamID'] = \
-        ['beam_id', beam_id, 'Beam identification (Beam ID)']
+        metadata_dict['identification/burstID'] = \
+            ['burst_id',
+             ALL_PRODUCTS,
+             str(burst_in.burst_id),
+             'Burst identification (burst ID)']
 
-    metadata_dict['identification/zeroDopplerStartTime'] = \
-        ['zero_doppler_start_time',
-         burst_in.sensing_start.strftime(DATE_TIME_METADATA_FORMAT),
-         'Azimuth start time of the product in the format YYYY-MM-DDThh:mm:ss.sZ'] # 1.6.3
-    metadata_dict['identification/zeroDopplerEndTime'] = \
-        ['zero_doppler_end_time',
-         burst_in.sensing_stop.strftime(DATE_TIME_METADATA_FORMAT),
-         'Azimuth stop time of the product in the format YYYY-MM-DDThh:mm:ss.sZ']  # 1.6.3
+        beam_id = burst_in.swath_name.upper()
+        metadata_dict['identification/beamID'] = \
+            ['beam_id',
+             ALL_PRODUCTS,
+             beam_id,
+             'Beam identification (Beam ID)']
 
-    metadata_dict['metadata/sourceData/zeroDopplerStartTime'] = \
-        [None,
-         burst_in.sensing_start.strftime(DATE_TIME_METADATA_FORMAT),
-         'Azimuth start time of the product in the format YYYY-MM-DDThh:mm:ss.sZ'] # 1.6.3
-    metadata_dict['metadata/sourceData/zeroDopplerEndTime'] = \
-        [None,
-         burst_in.sensing_stop.strftime(DATE_TIME_METADATA_FORMAT),
-         'Azimuth stop time of the product in the format YYYY-MM-DDThh:mm:ss.sZ']  # 1.6.3
-    metadata_dict['metadata/sourceData/numberOfAzimuthLines'] = \
-        ['source_data_number_of_azimuth_lines',
-         burst_in.length,
-         'Number of azimuth lines within the source data product']
+        # TODO: Update for static layers!!!
+        metadata_dict['identification/zeroDopplerStartTime'] = \
+            ['zero_doppler_start_time',
+             ALL_PRODUCTS,
+             burst_in.sensing_start.strftime(DATE_TIME_METADATA_FORMAT),
+             'Azimuth start time of the product in the format YYYY-MM-DDThh:mm:ss.sZ'] # 1.6.3
 
-    metadata_dict['metadata/sourceData/numberOfRangeSamples'] = \
-        ['source_data_number_of_range_samples',
-         burst_in.width,
-         'Number of slant range samples for each azimuth line within the source data']
-    metadata_dict['metadata/sourceData/slantRangeStart'] = \
-        ['source_data_slant_range_start',
-         burst_in.starting_range,
-         'Source data slant range start distance']
+        # TODO: Update for static layers!!!
+        metadata_dict['identification/zeroDopplerEndTime'] = \
+            ['zero_doppler_end_time',
+             ALL_PRODUCTS,
+             burst_in.sensing_stop.strftime(DATE_TIME_METADATA_FORMAT),
+             'Azimuth stop time of the product in the format'
+             ' YYYY-MM-DDThh:mm:ss.sZ']  # 1.6.3
 
-    # Add RFI metadata into `metadata_dict`
-    rfi_metadata_dict = get_rfi_metadata_dict(burst_in,
-                                              'metadata/QA/rfiInformation')
-    metadata_dict.update(rfi_metadata_dict)
+        metadata_dict['metadata/sourceData/zeroDopplerStartTime'] = \
+            ['source_data_zero_doppler_start_time',
+             ALL_PRODUCTS,
+             burst_in.sensing_start.strftime(DATE_TIME_METADATA_FORMAT),
+             'Azimuth start time of the input product in the format'
+             ' YYYY-MM-DDThh:mm:ss.sZ'] # 1.6.3
+        metadata_dict['metadata/sourceData/zeroDopplerEndTime'] = \
+            ['source_data_zero_doppler_end_time',
+             ALL_PRODUCTS,
+             burst_in.sensing_stop.strftime(DATE_TIME_METADATA_FORMAT),
+             'Azimuth stop time of the input product in the format'
+             ' YYYY-MM-DDThh:mm:ss.sZ']  # 1.6.3
+        metadata_dict['metadata/sourceData/numberOfAzimuthLines'] = \
+            ['source_data_number_of_azimuth_lines',
+             ALL_PRODUCTS,
+             burst_in.length,
+             'Number of azimuth lines within the source data product']
 
-    return metadata_dict
+        metadata_dict['metadata/sourceData/numberOfRangeSamples'] = \
+            ['source_data_number_of_range_samples',
+             ALL_PRODUCTS,
+             burst_in.width,
+             'Number of slant range samples for each azimuth line within the'
+             ' source data']
+        metadata_dict['metadata/sourceData/slantRangeStart'] = \
+            ['source_data_slant_range_start',
+             ALL_PRODUCTS,
+             burst_in.starting_range,
+             'Source data slant range start distance']
+
+    this_product_metadata_dict = {}
+    for h5_path, (geotiff_field, flag_all_products, data, description) in \
+            metadata_dict.items():
+        if processing_type == 'STATIC_LAYERS' and not flag_all_products:
+            continue
+        this_product_metadata_dict[h5_path] = [geotiff_field, data,
+                                               description]
+
+    if not is_mosaic:
+
+        # Add RFI metadata into `metadata_dict`
+        rfi_metadata_dict = get_rfi_metadata_dict(burst_in,
+                                                  'metadata/QA/rfiInformation')
+        this_product_metadata_dict.update(rfi_metadata_dict)
+
+    return this_product_metadata_dict
 
 
 def all_metadata_dict_to_geotiff_metadata_dict(metadata_dict):

--- a/src/rtc/rtc_s1.py
+++ b/src/rtc/rtc_s1.py
@@ -611,6 +611,12 @@ def run_parallel(cfg: RunConfig, logfile_path, flag_logger_full_format):
         burst_product_id = burst_product_id_list[burst_index]
         logger.info(f'    product ID: {burst_product_id}')
 
+        if processing_type == 'STATIC_LAYERS':
+            # for STATIC_LAYERS, we just use the first polarization as
+            # reference
+            pol_list = [pol_list[0]]
+            burst_pol_dict = {pol_list[0]: burst}
+
         flag_bursts_files_are_temporary = (not save_bursts or
                                            save_imagery_as_hdf5)
         flag_bursts_secondary_files_are_temporary = (

--- a/src/rtc/rtc_s1_single_job.py
+++ b/src/rtc/rtc_s1_single_job.py
@@ -1486,6 +1486,35 @@ def run_single_job(cfg: RunConfig):
                             geogrid.spacing_x, geogrid.spacing_y,
                             geogrid.width, geogrid.length, geogrid.epsg)
 
+            if rtc_area_factor_mode != 'auto':
+
+
+
+
+
+                # TODO! This code should be moved to runconfig after `area_factor_mode`
+                # is added to geocode() in ISCE3
+                if rtc_area_factor_mode == 'pixel_area':
+                    rtc_area_factor_mode_enum = \
+                        isce3.geometry.RtcAreaFactorMode.PixelArea
+                elif rtc_area_factor_mode == 'projection_angle':
+                    rtc_area_factor_mode_enum = \
+                        isce3.geometry.RtcAreaFactorMode.BlocksGeogridAndRadarGrid
+                elif (rtc_area_factor_mode == 'auto' or
+                        rtc_area_factor_mode is None):
+                    rtc_area_factor_mode_enum = \
+                        isce3.geometry.RtcAreaFactorMode.Auto
+                else:
+                    err_msg = f"ERROR invalid area factor mode: {rtc_area_factor_mode}"
+                    raise ValueError(err_msg)
+
+
+
+
+
+
+                geocode_kwargs['rtc_area_factor_mode'] = rtc_area_factor_mode_enum
+
             geo_obj.geocode(radar_grid=radar_grid,
                             input_raster=rdr_burst_raster,
                             output_raster=geo_burst_raster,
@@ -1499,7 +1528,6 @@ def run_single_job(cfg: RunConfig):
                             rtc_min_value_db=rtc_min_value_db,
                             rtc_upsampling=rtc_upsampling,
                             rtc_algorithm=rtc_algorithm,
-                            rtc_area_factor_mode=rtc_area_factor_mode,
                             abs_cal_factor=abs_cal_factor,
                             flag_upsample_radar_grid=flag_upsample_radar_grid,
                             clip_min=clip_min,

--- a/src/rtc/rtc_s1_single_job.py
+++ b/src/rtc/rtc_s1_single_job.py
@@ -1304,10 +1304,10 @@ def run_single_job(cfg: RunConfig):
         input_file_list = []
         for pol, burst_pol in burst_pol_dict.items():
             temp_slc_path = \
-                os.path.join(burst_scratch_path, f'rslc_{pol}.vrt')
+                os.path.join(burst_scratch_path, f'slc_{pol}.vrt')
             temp_slc_corrected_path = \
                 os.path.join(burst_scratch_path,
-                             f'rslc_{pol}_corrected.{imagery_extension}')
+                             f'slc_{pol}_corrected.{imagery_extension}')
 
             if (flag_process and (flag_apply_thermal_noise_correction or
                 flag_apply_abs_rad_correction) and 
@@ -1481,7 +1481,7 @@ def run_single_job(cfg: RunConfig):
             if len(input_file_list) == 1:
                 rdr_burst_raster = isce3.io.Raster(input_file_list[0])
             else:
-                temp_vrt_path = f'{burst_scratch_path}/rslc.vrt'
+                temp_vrt_path = f'{burst_scratch_path}/slc.vrt'
                 gdal.BuildVRT(temp_vrt_path, input_file_list,
                               options=vrt_options_mosaic)
                 rdr_burst_raster = isce3.io.Raster(temp_vrt_path)

--- a/src/rtc/rtc_s1_single_job.py
+++ b/src/rtc/rtc_s1_single_job.py
@@ -1035,6 +1035,7 @@ def run_single_job(cfg: RunConfig):
     input_terrain_radiometry = rtc_namespace.input_terrain_radiometry
     rtc_min_value_db = rtc_namespace.rtc_min_value_db
     rtc_upsampling = rtc_namespace.dem_upsampling
+    rtc_area_factor_mode = rtc_namespace.area_factor_mode
     if (flag_apply_rtc and output_terrain_radiometry ==
             isce3.geometry.RtcOutputTerrainRadiometry.SIGMA_NAUGHT):
         rtc_anf_suffix = "sigma0_to_beta0"
@@ -1498,6 +1499,7 @@ def run_single_job(cfg: RunConfig):
                             rtc_min_value_db=rtc_min_value_db,
                             rtc_upsampling=rtc_upsampling,
                             rtc_algorithm=rtc_algorithm,
+                            rtc_area_factor_mode=rtc_area_factor_mode,
                             abs_cal_factor=abs_cal_factor,
                             flag_upsample_radar_grid=flag_upsample_radar_grid,
                             clip_min=clip_min,

--- a/src/rtc/rtc_s1_single_job.py
+++ b/src/rtc/rtc_s1_single_job.py
@@ -1035,7 +1035,7 @@ def run_single_job(cfg: RunConfig):
     input_terrain_radiometry = rtc_namespace.input_terrain_radiometry
     rtc_min_value_db = rtc_namespace.rtc_min_value_db
     rtc_upsampling = rtc_namespace.dem_upsampling
-    rtc_area_factor_mode = rtc_namespace.area_factor_mode
+    rtc_area_beta_mode = rtc_namespace.area_beta_mode
     if (flag_apply_rtc and output_terrain_radiometry ==
             isce3.geometry.RtcOutputTerrainRadiometry.SIGMA_NAUGHT):
         rtc_anf_suffix = "sigma0_to_beta0"
@@ -1486,26 +1486,26 @@ def run_single_job(cfg: RunConfig):
                             geogrid.spacing_x, geogrid.spacing_y,
                             geogrid.width, geogrid.length, geogrid.epsg)
 
-            if rtc_area_factor_mode != 'auto':
+            if rtc_area_beta_mode != 'auto':
 
 
 
 
 
-                # TODO! This code should be moved to runconfig after `area_factor_mode`
+                # TODO! This code should be moved to runconfig after `area_beta_mode`
                 # is added to geocode() in ISCE3
-                if rtc_area_factor_mode == 'pixel_area':
-                    rtc_area_factor_mode_enum = \
-                        isce3.geometry.RtcAreaFactorMode.PixelArea
-                elif rtc_area_factor_mode == 'projection_angle':
-                    rtc_area_factor_mode_enum = \
-                        isce3.geometry.RtcAreaFactorMode.BlocksGeogridAndRadarGrid
-                elif (rtc_area_factor_mode == 'auto' or
-                        rtc_area_factor_mode is None):
-                    rtc_area_factor_mode_enum = \
-                        isce3.geometry.RtcAreaFactorMode.Auto
+                if rtc_area_beta_mode == 'pixel_area':
+                    rtc_area_beta_mode_enum = \
+                        isce3.geometry.RtcAreaBetaMode.PIXEL_AREA
+                elif rtc_area_beta_mode == 'projection_angle':
+                    rtc_area_beta_mode_enum = \
+                        isce3.geometry.RtcAreaBetaMode.PROJECTION_ANGLE
+                elif (rtc_area_beta_mode == 'auto' or
+                        rtc_area_beta_mode is None):
+                    rtc_area_beta_mode_enum = \
+                        isce3.geometry.RtcAreaBetaMode.AUTO
                 else:
-                    err_msg = f"ERROR invalid area factor mode: {rtc_area_factor_mode}"
+                    err_msg = f"ERROR invalid area beta mode: {rtc_area_beta_mode}"
                     raise ValueError(err_msg)
 
 
@@ -1513,7 +1513,7 @@ def run_single_job(cfg: RunConfig):
 
 
 
-                geocode_kwargs['rtc_area_factor_mode'] = rtc_area_factor_mode_enum
+                geocode_kwargs['rtc_area_beta_mode'] = rtc_area_beta_mode_enum
 
             geo_obj.geocode(radar_grid=radar_grid,
                             input_raster=rdr_burst_raster,

--- a/src/rtc/schemas/rtc_s1.yaml
+++ b/src/rtc/schemas/rtc_s1.yaml
@@ -175,6 +175,9 @@ rtc_options:
     # RTC DEM upsampling
     dem_upsampling: int(min=1, required=False)
 
+    # RTC area factor mode
+    area_factor_mode: enum('auto', 'pixel_area', 'projection_angle', required=False)
+
 
 geocoding_options:
 

--- a/src/rtc/schemas/rtc_s1.yaml
+++ b/src/rtc/schemas/rtc_s1.yaml
@@ -175,8 +175,8 @@ rtc_options:
     # RTC DEM upsampling
     dem_upsampling: int(min=1, required=False)
 
-    # RTC area factor mode
-    area_factor_mode: enum('auto', 'pixel_area', 'projection_angle', required=False)
+    # RTC area beta mode
+    area_beta_mode: enum('auto', 'pixel_area', 'projection_angle', required=False)
 
 
 geocoding_options:

--- a/src/rtc/schemas/rtc_s1.yaml
+++ b/src/rtc/schemas/rtc_s1.yaml
@@ -181,7 +181,7 @@ rtc_options:
 
 geocoding_options:
 
-    # OPTIONAL - Apply RSLC metadata valid-samples sub-swath masking
+    # OPTIONAL - Apply valid-samples sub-swath masking
     apply_valid_samples_sub_swath_masking: bool(required=False)
 
     # OPTIONAL - Apply shadow masking

--- a/tests/runconfigs/s1b_los_angeles.yaml
+++ b/tests/runconfigs/s1b_los_angeles.yaml
@@ -128,7 +128,7 @@ runconfig:
           # OPTIONAL - Mechanism to specify output posting and DEM
           geocoding:
 
-              # OPTIONAL - Apply RSLC metadata valid-samples sub-swath masking
+              # OPTIONAL - Apply valid-samples sub-swath masking
               apply_valid_samples_sub_swath_masking: True
 
               # OPTIONAL - Apply shadow masking

--- a/tests/test_rtc_s1_workflow.py
+++ b/tests/test_rtc_s1_workflow.py
@@ -32,7 +32,7 @@ def _load_cfg_parameters(cfg):
     product_id = cfg.groups.product_group.product_id
     if product_id is None:
         product_id = 'OPERA_L2_RTC-S1_{burst_id}'
-    product_prefix = f'{product_id}_v{product_version}'
+    product_prefix = product_id
 
     output_imagery_format = \
         cfg.groups.product_group.output_imagery_format


### PR DESCRIPTION
This PR follows PR #47 and updates the RTC-S1 SAS after Cal/Val Release:
- Create specific metadata for RTC-S1 static layer products;
- Fixes the generation of RTC-S1 static layers by the parallelized script `rtc_s1.py`;
- Add selection of the RTC area factor mode (requires update in ISCE3);
- Add metadata field range bandwidth.