### PR TITLE
Quick fix to prevent the multilooking of the layover/shadow-mask radargrid for standard RTC-S1 products

### DIFF
--- a/src/rtc/rtc_s1_single_job.py
+++ b/src/rtc/rtc_s1_single_job.py
@@ -1430,9 +1430,12 @@ def run_single_job(cfg: RunConfig):
                 logger.info('    computing layover shadow mask for'
                             f' {burst_id}')
 
-                radar_grid_layover_shadow_mask = radar_grid.multilook(
-                    STATIC_LAYERS_LAYOVER_SHADOW_MASK_MULTILOOK_FACTOR,
-                    STATIC_LAYERS_LAYOVER_SHADOW_MASK_MULTILOOK_FACTOR)
+                if processing_type == 'STATIC_LAYERS':
+                    radar_grid_layover_shadow_mask = radar_grid.multilook(
+                        STATIC_LAYERS_LAYOVER_SHADOW_MASK_MULTILOOK_FACTOR,
+                        STATIC_LAYERS_LAYOVER_SHADOW_MASK_MULTILOOK_FACTOR)
+                else:
+                    radar_grid_layover_shadow_mask = radar_grid
 
                 slantrange_layover_shadow_mask_raster = \
                     compute_layover_shadow_mask(


### PR DESCRIPTION
This PR fixes a bug introduced recently that is causing the workflow to break when generating RTC-S1 products using the layover shadow mask. It updates the code to only multilook the layover/shadow-mask radar grid if `processing_type` equals `STATIC_LAYERS`.