### PR TITLE
add range and azimuth range to source metadata

### DIFF
--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -1328,7 +1328,8 @@ def get_range_azimuth_resolution(burst: Sentinel1BurstSlc):
 
     Reference
     ---------
-    https://sentinels.copernicus.eu/web/sentinel/technical-guides/sentinel-1-sar/products-algorithms/level-1/single-look-complex/interferometric-wide-swath
+    https://sentinels.copernicus.eu/web/sentinel/technical-guides/sentinel-1-sar/
+    products-algorithms/level-1/single-look-complex/interferometric-wide-swath
     '''
 
     resolution_subswath_range_azimuth_dict = {

--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -367,7 +367,8 @@ def get_metadata_dict(product_id: str,
     dem_file_description = cfg_in.dem_file_description
 
     # Slant range and azimuth resolution of the sensor
-    slant_range_resolution, azimuth_resolution = get_range_azimuth_resolution(burst_in)
+    slant_range_resolution, azimuth_resolution = \
+        get_range_azimuth_resolution(burst_in)
 
     if not dem_file_description:
         # If the DEM description is not provided, use DEM source
@@ -622,7 +623,7 @@ def get_metadata_dict(product_id: str,
              ALL_PRODUCTS,
              azimuth_resolution,
              'Azimuth resolution of the source data in meters'],
-        'metadata/sourceData/slantRangeResolutuion':  # 1.6.7
+        'metadata/sourceData/slantRangeResolutionInMeters':  # 1.6.7
             ['source_data_slant_range_resolution',
              ALL_PRODUCTS,
              slant_range_resolution,
@@ -1318,12 +1319,12 @@ def get_range_azimuth_resolution(burst: Sentinel1BurstSlc):
     burst: Sentinel1BurstSlc
         Burst object to compute the resolution
 
-    returns
+    Returns
     -------
     slant_range_resolution: float
-        Slant range recolution
+        Slant-range resolution in meters
     azimuth_resolution: float
-        Azimuth resolution
+        Azimuth resolution in meters
 
     Reference
     ---------

--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -618,16 +618,16 @@ def get_metadata_dict(product_id: str,
              ALL_PRODUCTS,
              burst_in.range_pixel_spacing,
              'Slant range spacing of the source data in meters'],
-        'metadata/sourceData/azimuthResolution':  # 1.6.7
-            ['source_data_azimuth_resolution',
+        'metadata/sourceData/azimuthResolutionInMeters':  # 1.6.7
+            ['source_data_azimuth_resolution_in_meters',
              ALL_PRODUCTS,
              azimuth_resolution,
              'Azimuth resolution of the source data in meters'],
         'metadata/sourceData/slantRangeResolutionInMeters':  # 1.6.7
-            ['source_data_slant_range_resolution',
+            ['source_data_slant_range_resolution_in_meters',
              ALL_PRODUCTS,
              slant_range_resolution,
-             'Slant range resoluton of the source data in meters'],
+             'Slant-range resolution of the source data in meters'],
 
         # 'metadata/sourceData/azimuthResolution':  # 1.6.7
         #    ['source_azimuth_resolution',
@@ -1314,7 +1314,7 @@ def get_range_azimuth_resolution(burst: Sentinel1BurstSlc):
     '''
     Get the range and azimuth resolution based on the ESA documentation
 
-    Paremeters
+    Parameters
     ----------
     burst: Sentinel1BurstSlc
         Burst object to compute the resolution


### PR DESCRIPTION
This PR is to add range and azimuth resolution to the source metadata.

Below are the references to compute the resolutions

- https://sentinels.copernicus.eu/web/sentinel/technical-guides/sentinel-1-sar/sar-instrument (for antenna length)
- Francesco De Zan and Andrea Monti Guarnieri, TOPSAR: Terrain Observation by Progressive Scans, IEEE TRANSACTIONS ON GEOSCIENCE AND REMOTE SENSING, 44(9) pp. 2352-2360
    