### PR TITLE
More changes after calval point release

### DIFF
--- a/src/rtc/defaults/rtc_s1.yaml
+++ b/src/rtc/defaults/rtc_s1.yaml
@@ -127,9 +127,6 @@ runconfig:
             # Apply thermal noise correction
             apply_thermal_noise_correction: True
 
-            # Compute geolocation correction LUTs and apply it
-            apply_correction_luts: True
-
             # slant range spacing of the correction LUT in meters
             correction_lut_range_spacing_in_meters: 120
             # Azimuth time spacing of the correction LUT in meters

--- a/src/rtc/defaults/rtc_s1.yaml
+++ b/src/rtc/defaults/rtc_s1.yaml
@@ -138,8 +138,8 @@ runconfig:
             # Apply bistatic delay correction
             apply_bistatic_delay_correction: True
 
-            # Apply dry tropospheric delay correction
-            apply_dry_tropospheric_delay_correction: True
+            # Apply static tropospheric delay correction
+            apply_static_tropospheric_delay_correction: True
  
             # OPTIONAL - to control behavior of RTC module
             # (only applicable if geocode.apply_rtc is True)

--- a/src/rtc/defaults/rtc_s1.yaml
+++ b/src/rtc/defaults/rtc_s1.yaml
@@ -246,6 +246,12 @@ runconfig:
                 # Double SLC sampling in the range direction
                 upsample_radargrid: False
 
+                # Fields to populate the products' metadata required by
+                # CEOS Analysis Ready Data specifications
+                estimated_geometric_accuracy_bias_x:
+                estimated_geometric_accuracy_bias_y:
+                estimated_geometric_accuracy_stddev_x:
+                estimated_geometric_accuracy_stddev_y:
 
                 bursts_geogrid:
 

--- a/src/rtc/defaults/rtc_s1_static.yaml
+++ b/src/rtc/defaults/rtc_s1_static.yaml
@@ -247,6 +247,13 @@ runconfig:
                 # Double SLC sampling in the range direction
                 upsample_radargrid: False
 
+                # Fields to populate the products' metadata required by
+                # CEOS Analysis Ready Data specifications
+                estimated_geometric_accuracy_bias_x:
+                estimated_geometric_accuracy_bias_y:
+                estimated_geometric_accuracy_stddev_x:
+                estimated_geometric_accuracy_stddev_y:
+
                 bursts_geogrid:
 
                     # Bursts' EPSG code. If not provided, `output_epsg` will

--- a/src/rtc/defaults/rtc_s1_static.yaml
+++ b/src/rtc/defaults/rtc_s1_static.yaml
@@ -139,8 +139,8 @@ runconfig:
             # Apply bistatic delay correction
             apply_bistatic_delay_correction: False
 
-            # Apply dry tropospheric delay correction
-            apply_dry_tropospheric_delay_correction: False
+            # Apply static tropospheric delay correction
+            apply_static_tropospheric_delay_correction: False
  
             # OPTIONAL - to control behavior of RTC module
             # (only applicable if geocode.apply_rtc is True)

--- a/src/rtc/defaults/rtc_s1_static.yaml
+++ b/src/rtc/defaults/rtc_s1_static.yaml
@@ -128,9 +128,6 @@ runconfig:
             # Apply thermal noise correction
             apply_thermal_noise_correction: True
 
-            # Compute geolocation correction LUTs and apply it
-            apply_correction_luts: True
-
             # slant range spacing of the correction LUT in meters
             correction_lut_range_spacing_in_meters: 120
             # Azimuth time spacing of the correction LUT in meters
@@ -140,10 +137,10 @@ runconfig:
             apply_rtc: True
 
             # Apply bistatic delay correction
-            apply_bistatic_delay_correction: True
+            apply_bistatic_delay_correction: False
 
             # Apply dry tropospheric delay correction
-            apply_dry_tropospheric_delay_correction: True
+            apply_dry_tropospheric_delay_correction: False
  
             # OPTIONAL - to control behavior of RTC module
             # (only applicable if geocode.apply_rtc is True)

--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -791,7 +791,8 @@ def get_metadata_dict(product_id: str,
         # 1.7.8
         ('metadata/processingInformation/parameters/geocoding/'
             '/ceosAnalysisReadyDataPixelCoordinateConvention'):
-            ['ceos_analysis_ready_data_pixel_coordinate_convention',
+            ['processing_information_'
+             'ceos_analysis_ready_data_pixel_coordinate_convention',
              ALL_PRODUCTS,
              'ULC',
              'CEOS Analysis Ready Data (CARD) pixel coordinate convention'],
@@ -1004,7 +1005,7 @@ def get_metadata_dict(product_id: str,
 
         # Attribute `epsg` for HDF5 dataset /identification/boundingPolygon
         metadata_dict['identification/boundingPolygon[epsg]'] = \
-            ['bouding_polygon_epsg_code',
+            ['bounding_polygon_epsg_code',
              STANDARD_RTC_S1_ONLY,
              '4326',
              'Bounding polygon EPSG code']

--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -421,13 +421,13 @@ def get_metadata_dict(product_id: str,
         cfg_in.groups.processing.geocoding.estimated_geometric_accuracy_stddev_x
 
     if not estimated_geometric_accuracy_bias_y:
-        estimated_geometric_accuracy_bias_y = ''
+        estimated_geometric_accuracy_bias_y = '(UNSPECIFIED)'
     if not estimated_geometric_accuracy_bias_x:
-        estimated_geometric_accuracy_bias_x = ''
+        estimated_geometric_accuracy_bias_x = '(UNSPECIFIED)'
     if not estimated_geometric_accuracy_stddev_y:
-        estimated_geometric_accuracy_stddev_y = ''
+        estimated_geometric_accuracy_stddev_y = '(UNSPECIFIED)'
     if not estimated_geometric_accuracy_stddev_x:
-        estimated_geometric_accuracy_stddev_x = ''
+        estimated_geometric_accuracy_stddev_x = '(UNSPECIFIED)'
 
     subswath_id = burst_in.swath_name.upper()
 
@@ -440,7 +440,7 @@ def get_metadata_dict(product_id: str,
     #     Metadata field description
     # ]
 
-    # where the constants bellow represent the states for flag (*1)
+    # where the constants below represent the states for flag (*1)
     ALL_PRODUCTS = True
     STANDARD_RTC_S1_ONLY = False
 

--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -895,11 +895,6 @@ def get_metadata_dict(product_id: str,
              [burst_in.burst_calibration.basename_cads,
               burst_in.burst_noise.basename_nads],
              'List of input annotation files used'],
-        'metadata/processingInformation/inputs/configFiles':
-            ['input_config_files',
-             ALL_PRODUCTS,
-             cfg_in.run_config_path,
-             'List of input config files used'],
         'metadata/processingInformation/inputs/demSource':
             ['input_dem_source',
              ALL_PRODUCTS,

--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -730,12 +730,12 @@ def get_metadata_dict(product_id: str,
              'Flag to indicate if radiometric terrain correction (RTC) has'
              ' been applied'],
         ('metadata/processingInformation/parameters/'
-            'dryTroposphericGeolocationCorrectionApplied'):
+            'staticTroposphericGeolocationCorrectionApplied'):
             ['processing_information'
-             '_dry_tropospheric_geolocation_correction_applied',
+             '_static_tropospheric_geolocation_correction_applied',
              ALL_PRODUCTS,
-             cfg_in.groups.processing.apply_dry_tropospheric_delay_correction,
-             'Flag to indicate if the dry tropospheric correction has been'
+             cfg_in.groups.processing.apply_static_tropospheric_delay_correction,
+             'Flag to indicate if the static tropospheric correction has been'
              ' applied'],
         ('metadata/processingInformation/parameters/'
             'wetTroposphericGeolocationCorrectionApplied'):

--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -1036,12 +1036,12 @@ def get_metadata_dict(product_id: str,
              str(burst_in.burst_id),
              'Burst identification (burst ID)']
 
-        beam_id = burst_in.swath_name.upper()
-        metadata_dict['identification/beamID'] = \
-            ['beam_id',
+        subswath_id = burst_in.swath_name.upper()
+        metadata_dict['identification/subSwathID'] = \
+            ['sub_swath_id',
              ALL_PRODUCTS,
-             beam_id,
-             'Beam identification (Beam ID)']
+             subswath_id,
+             'Sub-swath identification']
 
         # TODO: Update for static layers!!!
         metadata_dict['identification/zeroDopplerStartTime'] = \

--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -410,10 +410,9 @@ def get_metadata_dict(product_id: str,
     if not mosaic_snap_y:
         mosaic_snap_y = '(DISABLED)'
 
-    # mission_id = 'Sentinel'
+    subswath_id = burst_in.swath_name.upper()
 
-    # Manifests the field names, corresponding values from RTC workflow, and
-    # the description. To extend this, add the lines with the format below:
+    # `metadata_dict`` is organized as follows:
     # 'field_name': [
     #     GeoTIFF metadata field,
     #     Flag indicating whether the field is present in RTC-S1 Static Layer
@@ -422,7 +421,7 @@ def get_metadata_dict(product_id: str,
     #     Metadata field description
     # ]
 
-    # Constants to represent flag (*1) above
+    # where the constants bellow represent the states for flag (*1)
     ALL_PRODUCTS = True
     STANDARD_RTC_S1_ONLY = False
 
@@ -486,7 +485,7 @@ def get_metadata_dict(product_id: str,
         'identification/acquisitionMode':
             ['acquisition_mode',
              ALL_PRODUCTS,
-             'Interferometric Wide (IW)',
+             subswath_id[0:2],
              'Acquisition mode'],
         'identification/ceosAnalysisReadyDataProductType':  # 1.3
             ['ceos_analysis_ready_data_product_type',
@@ -1031,7 +1030,6 @@ def get_metadata_dict(product_id: str,
              str(burst_in.burst_id),
              'Burst identification (burst ID)']
 
-        subswath_id = burst_in.swath_name.upper()
         metadata_dict['identification/subSwathID'] = \
             ['sub_swath_id',
              ALL_PRODUCTS,

--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -421,13 +421,13 @@ def get_metadata_dict(product_id: str,
         cfg_in.groups.processing.geocoding.estimated_geometric_accuracy_stddev_x
 
     if not estimated_geometric_accuracy_bias_y:
-        estimated_geometric_accuracy_bias_y = '(UNDETERMINED)'
+        estimated_geometric_accuracy_bias_y = ''
     if not estimated_geometric_accuracy_bias_x:
-        estimated_geometric_accuracy_bias_x = '(UNDETERMINED)'
+        estimated_geometric_accuracy_bias_x = ''
     if not estimated_geometric_accuracy_stddev_y:
-        estimated_geometric_accuracy_stddev_y = '(UNDETERMINED)'
+        estimated_geometric_accuracy_stddev_y = ''
     if not estimated_geometric_accuracy_stddev_x:
-        estimated_geometric_accuracy_stddev_x = '(UNDETERMINED)'
+        estimated_geometric_accuracy_stddev_x = ''
 
     subswath_id = burst_in.swath_name.upper()
 
@@ -1358,7 +1358,7 @@ def get_rfi_metadata_dict(burst_in, rfi_root_path):
 
     is_rfi_info_empty = burst_in.burst_rfi_info is None
     rfi_metadata_dict[f'{rfi_root_path}/isRfiInfoAvailable'] =\
-        ['is_rfi_info_available',
+        ['qa_rfi_info_available',
          not is_rfi_info_empty,
          'A flag to indicate whether RFI information is available in the source data']
 

--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -245,7 +245,7 @@ def create_hdf5_file(product_id, output_hdf5_file, orbit, burst, cfg,
         HDF5 object into which write the metadata
     orbit: isce3.core.Orbit
         Orbit ISCE3 object
-    burst: Sentinel1BurstCls
+    burst: Sentinel1BurstSlc
         Source burst of the RTC
     cfg: RunConfig
         A class that contains the information defined in runconfig
@@ -320,7 +320,7 @@ def get_metadata_dict(product_id: str,
     -----------
     product_id: str
         Product ID
-    burst_in: Sentinel1BurstCls
+    burst_in: Sentinel1BurstSlc
         Source burst of the RTC
     cfg_in: RunConfig
         A class that contains the information defined in runconfig
@@ -1177,7 +1177,7 @@ def populate_metadata_group(product_id: str,
         Product ID
     h5py_obj: h5py.File
         HDF5 object into which write the metadata
-    burst_in: Sentinel1BurstCls
+    burst_in: Sentinel1BurstSlc
         Source burst of the RTC
     cfg_in: RunConfig
         A class that contains the information defined in runconfig

--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -526,11 +526,11 @@ def get_metadata_dict(product_id: str,
              ' Reformatted, unprocessed instrument data; L1: Processed'
              ' instrument data in radar coordinates system; and L2:'
              ' Processed instrument data in geocoded coordinates system'],
-        'identification/productID':
-            ['product_id',
-             ALL_PRODUCTS,
-             product_id,
-             'Product identifier'],
+        # 'identification/productID':
+        #    ['product_id',
+        #     ALL_PRODUCTS,
+        #     product_id,
+        #     'Product identifier'],
 
         'identification/processingType':
             ['processing_type',

--- a/src/rtc/rtc_s1.py
+++ b/src/rtc/rtc_s1.py
@@ -545,7 +545,7 @@ def run_parallel(cfg: RunConfig, logfile_path, flag_logger_full_format):
         burst_product_id = populate_product_id(
             runconfig_product_id, burst, processing_datetime, product_version,
             pixel_spacing_avg, product_type, rtc_s1_static_validity_start_date,
-            is_mosaic=True)
+            is_mosaic=False)
         burst_product_id_list.append(burst_product_id)
 
     # burst files are saved in scratch dir

--- a/src/rtc/rtc_s1_single_job.py
+++ b/src/rtc/rtc_s1_single_job.py
@@ -136,8 +136,8 @@ def populate_product_id(product_id, burst_in, processing_datetime,
 
 
 def compute_correction_lut(burst_in, dem_raster, scratch_path,
-                           rg_step_meters=120,
-                           az_step_meters=120,
+                           rg_step_meters,
+                           az_step_meters,
                            apply_bistatic_delay_correction,
                            apply_dry_tropospheric_delay_correction):
     '''

--- a/src/rtc/rtc_s1_single_job.py
+++ b/src/rtc/rtc_s1_single_job.py
@@ -139,7 +139,7 @@ def compute_correction_lut(burst_in, dem_raster, scratch_path,
                            rg_step_meters,
                            az_step_meters,
                            apply_bistatic_delay_correction,
-                           apply_dry_tropospheric_delay_correction):
+                           apply_static_tropospheric_delay_correction):
     '''
     Compute lookup table for geolocation correction.
     Applied corrections are: bistatic delay (azimuth),
@@ -159,8 +159,8 @@ def compute_correction_lut(burst_in, dem_raster, scratch_path,
         LUT spacing in azimth direction. Unit: meters
     apply_bistatic_delay_correction: bool
         Flag to indicate whether the bistatic delay correciton should be applied
-    apply_dry_tropospheric_delay_correction: bool
-        Flag to indicate whether the dry tropospheric delay correction should be
+    apply_static_tropospheric_delay_correction: bool
+        Flag to indicate whether the static tropospheric delay correction should be
         applied
 
     Returns
@@ -173,7 +173,7 @@ def compute_correction_lut(burst_in, dem_raster, scratch_path,
     az_lut = None
 
     if (not apply_bistatic_delay_correction and
-            not apply_dry_tropospheric_delay_correction):
+            not apply_static_tropospheric_delay_correction):
         return rg_lut, az_lut
 
     # approximate conversion of az_step_meters from meters to seconds
@@ -197,7 +197,7 @@ def compute_correction_lut(burst_in, dem_raster, scratch_path,
                                   bistatic_delay.y_spacing,
                                   -bistatic_delay.data)
 
-    if not apply_dry_tropospheric_delay_correction:
+    if not apply_static_tropospheric_delay_correction:
         return rg_lut, az_lut
 
     # Calculate rdr2geo rasters
@@ -1075,8 +1075,8 @@ def run_single_job(cfg: RunConfig):
 
     apply_bistatic_delay_correction = \
         cfg.groups.processing.apply_bistatic_delay_correction
-    apply_dry_tropospheric_delay_correction = \
-        cfg.groups.processing.apply_dry_tropospheric_delay_correction
+    apply_static_tropospheric_delay_correction = \
+        cfg.groups.processing.apply_static_tropospheric_delay_correction
 
     # read product path group / output format
     runconfig_product_id = cfg.groups.product_group.product_id
@@ -1261,8 +1261,8 @@ def run_single_job(cfg: RunConfig):
                 f' {apply_shadow_masking}')
     logger.info(f'    apply bistatic delay correction:'
                 f' {apply_bistatic_delay_correction}')
-    logger.info(f'    apply dry tropospheric delay correction:'
-                f' {apply_dry_tropospheric_delay_correction}')
+    logger.info(f'    apply static tropospheric delay correction:'
+                f' {apply_static_tropospheric_delay_correction}')
     logger.info(f'    skip if already processed:'
                 f' {skip_if_output_files_exist}')
     logger.info(f'    scratch dir: {scratch_path}')
@@ -1604,7 +1604,7 @@ def run_single_job(cfg: RunConfig):
 
         # Calculate geolocation correction LUT
         if (flag_process and (apply_bistatic_delay_correction or
-                              apply_dry_tropospheric_delay_correction)):
+                              apply_static_tropospheric_delay_correction)):
 
             # Calculates the LUTs for one polarization in `burst_pol_dict`
             pol_burst_for_lut = next(iter(burst_pol_dict))
@@ -1616,7 +1616,7 @@ def run_single_job(cfg: RunConfig):
                 rg_step_meters,
                 az_step_meters,
                 apply_bistatic_delay_correction,
-                apply_dry_tropospheric_delay_correction)
+                apply_static_tropospheric_delay_correction)
 
             if az_lut is not None:
                 geocode_kwargs['az_time_correction'] = az_lut

--- a/src/rtc/rtc_s1_single_job.py
+++ b/src/rtc/rtc_s1_single_job.py
@@ -192,10 +192,10 @@ def compute_correction_lut(burst_in, dem_raster, scratch_path,
 
     if apply_bistatic_delay_correction:
         az_lut = isce3.core.LUT2d(bistatic_delay.x_start,
-                                bistatic_delay.y_start,
-                                bistatic_delay.x_spacing,
-                                bistatic_delay.y_spacing,
-                                -bistatic_delay.data)
+                                  bistatic_delay.y_start,
+                                  bistatic_delay.x_spacing,
+                                  bistatic_delay.y_spacing,
+                                  -bistatic_delay.data)
 
     if not apply_dry_tropospheric_delay_correction:
         return rg_lut, az_lut

--- a/src/rtc/rtc_s1_single_job.py
+++ b/src/rtc/rtc_s1_single_job.py
@@ -506,7 +506,9 @@ def append_metadata_to_geotiff_file(input_file, metadata_dict, product_id):
     layer_id = input_file_basename.replace(f'{product_id}_', '').split('.')[0]
 
     # Update metadata file name
-    existing_metadata['FILENAME'] = input_file_basename
+    # Note: commenting this line because the OPERA SDS may rename the output files
+    # making this field inconsistent
+    # existing_metadata['FILENAME'] = input_file_basename
 
     # Update metadata layer name (short description)
     if layer_id in layer_names_dict.keys():

--- a/src/rtc/rtc_s1_single_job.py
+++ b/src/rtc/rtc_s1_single_job.py
@@ -52,6 +52,7 @@ STATIC_LAYERS_RG_MARGIN = 0.2
 BROWSE_IMAGE_MIN_PERCENTILE = 3
 BROWSE_IMAGE_MAX_PERCENTILE = 97
 
+
 def populate_product_id(product_id, burst_in, processing_datetime,
                         product_version, pixel_spacing, product_type,
                         rtc_s1_static_validity_start_date, is_mosaic):
@@ -126,7 +127,7 @@ def populate_product_id(product_id, burst_in, processing_datetime,
     product_id = product_id.replace('{product_version}', f'v{product_version}')
 
     if not is_mosaic:
-        burst_id_file_name = burst_in.burst_id.upper().replace('_', '-')
+        burst_id_file_name = str(burst_in.burst_id).upper().replace('_', '-')
         product_id = product_id.replace('{burst_id}', f'T{burst_id_file_name}')
     else:
         product_id = product_id.replace('_{burst_id}', '')
@@ -1383,7 +1384,7 @@ def run_single_job(cfg: RunConfig):
         burst_product_id = populate_product_id(
             runconfig_product_id, burst, processing_datetime, product_version,
             pixel_spacing_avg, product_type, rtc_s1_static_validity_start_date,
-            is_mosaic=True)
+            is_mosaic=False)
 
         logger.info(f'    product ID: {burst_product_id}')
 
@@ -1478,9 +1479,7 @@ def run_single_job(cfg: RunConfig):
                 os.path.join(burst_scratch_path,
                              f'slc_{pol}_corrected.{imagery_extension}')
 
-            if (flag_process and (flag_apply_thermal_noise_correction or
-                flag_apply_abs_rad_correction) and 
-                    product_type == STATIC_LAYERS_PRODUCT_TYPE):
+            if (flag_process and product_type == STATIC_LAYERS_PRODUCT_TYPE):
                 fill_value = 1
                 build_empty_vrt(temp_slc_path, radar_grid.length,
                                 radar_grid.width, fill_value)
@@ -1555,7 +1554,7 @@ def run_single_job(cfg: RunConfig):
 
         # get sub_swaths metadata
         if (flag_process and apply_valid_samples_sub_swath_masking and
-                not product_type == STATIC_LAYERS_PRODUCT_TYPE):
+                product_type != STATIC_LAYERS_PRODUCT_TYPE):
             # Extract burst boundaries and create sub_swaths object to mask
             # invalid radar samples
             n_subswaths = 1

--- a/src/rtc/schemas/rtc_s1.yaml
+++ b/src/rtc/schemas/rtc_s1.yaml
@@ -164,8 +164,8 @@ processing_options:
     # Apply bistatic delay correction
     apply_bistatic_delay_correction: bool(required=False)
 
-    # Apply dry tropospheric delay correction
-    apply_dry_tropospheric_delay_correction: bool(required=False)
+    # Apply static tropospheric delay correction
+    apply_static_tropospheric_delay_correction: bool(required=False)
 
     # Radiometric Terrain Correction (RTC)
     rtc: include('rtc_options', required=False)

--- a/src/rtc/schemas/rtc_s1.yaml
+++ b/src/rtc/schemas/rtc_s1.yaml
@@ -152,11 +152,9 @@ processing_options:
     # Apply thermal noise correction
     apply_thermal_noise_correction: bool(required=False)
 
-    # Compute geolocation correction LUTs and apply it
-    apply_correction_luts: bool(required=False)
-
     # slant range spacing of the correction LUT in meters
     correction_lut_range_spacing_in_meters: num(required=False)
+
     # Azimuth time spacing of the correction LUT in meters
     correction_lut_azimuth_spacing_in_meters: num(required=False)
 

--- a/src/rtc/schemas/rtc_s1.yaml
+++ b/src/rtc/schemas/rtc_s1.yaml
@@ -270,6 +270,13 @@ geocoding_options:
     # Double SLC sampling in the range direction
     upsample_radargrid: bool(required=False)
 
+    # Fields to populate the products' metadata required by
+    # CEOS Analysis Ready Data specifications
+    estimated_geometric_accuracy_bias_x: num(required=False)
+    estimated_geometric_accuracy_bias_y: num(required=False)
+    estimated_geometric_accuracy_stddev_x: num(required=False)
+    estimated_geometric_accuracy_stddev_y: num(required=False)
+
     # Bursts geographic grid
     bursts_geogrid: include('output_grid_options', required=False)
 

--- a/tests/runconfigs/s1b_los_angeles.yaml
+++ b/tests/runconfigs/s1b_los_angeles.yaml
@@ -98,8 +98,8 @@ runconfig:
           # Apply bistatic delay correction
           apply_bistatic_delay_correction: True
 
-          # Apply dry tropospheric delay correction
-          apply_dry_tropospheric_delay_correction: True
+          # Apply static tropospheric delay correction
+          apply_static_tropospheric_delay_correction: True
 
           # OPTIONAL - to control behavior of RTC module
           # (only applicable if geocode.apply_rtc is True)


### PR DESCRIPTION
Updates:
- Fix burst file names to follow file naming convention.
- Make products' metadata consistent with products specs (fix type, update description, etc).
- Remove the runconfig flag `apply_correction_luts` and use existing flags `apply_bistatic_delay_correction` and `apply_dry_tropospheric_delay_correction` that were previously being ignored in the processing.
- Rename metadata field beam ID to sub-swath ID.
- Remove config files from the products' metadata.