### PR TITLE
orbit type when `orbit_file_path` is a list

### DIFF
--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -302,14 +302,13 @@ def save_orbit(orbit, orbit_group, orbit_file_path):
         data=np.string_(orbit.reference_epoch.isoformat()))
 
     # Orbit source/type
+    orbit_type = 'Undefined'
     if isinstance(orbit_file_path, str):
         orbit_file_basename = os.path.basename(orbit_file_path)
         if 'RESORB' in orbit_file_basename:
             orbit_type = 'RES restituted orbit'
         elif 'POEORB' in orbit_file_basename:
             orbit_type = 'POE precise orbit'
-        else:
-            orbit_type = 'Undefined'
 
     elif isinstance(orbit_file_path, list):
         orbit_type_list = []

--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -278,7 +278,7 @@ def create_hdf5_file(product_id, output_hdf5_file, orbit, burst, cfg,
 
     # save orbit
     orbit_group = hdf5_obj.require_group('/metadata/orbit')
-    save_orbit(orbit, orbit_group, os.path.basename(cfg.orbit_file_path))
+    save_orbit(orbit, orbit_group, cfg.orbit_file_path)
     return hdf5_obj
 
 
@@ -301,15 +301,29 @@ def save_orbit(orbit, orbit_group, orbit_file_path):
         'referenceEpoch',
         data=np.string_(orbit.reference_epoch.isoformat()))
 
-    # Orbit source/type    
-    if 'RESORB' in orbit_file_path:
-        orbit_type = 'RES restituted orbit'
-    elif 'POEORB' in orbit_file_path:
-        orbit_type = 'POE precise orbit'
-    else:
-        orbit_type = 'Undefined'
+    # Orbit source/type
+    if isinstance(orbit_file_path, str):
+        orbit_file_basename = os.path.basename(orbit_file_path)
+        if 'RESORB' in orbit_file_basename:
+            orbit_type = 'RES restituted orbit'
+        elif 'POEORB' in orbit_file_basename:
+            orbit_type = 'POE precise orbit'
+        else:
+            orbit_type = 'Undefined'
 
-    d = orbit_group.require_dataset("orbitType", (), "S25",
+    elif isinstance(orbit_file_path, list):
+        orbit_type_list = []
+        for individual_orbit_file in orbit_file_path:
+            if 'RESORB' in individual_orbit_file:
+                orbit_type_individual = 'RES restituted orbit'
+            elif 'POEORB' in individual_orbit_file:
+                orbit_type_individual = 'POE precise orbit'
+            else:
+                orbit_type_individual = 'Undefined'
+            orbit_type_list.append(orbit_type_individual)
+        orbit_type = '; '.join(orbit_type_list)
+
+    d = orbit_group.require_dataset("orbitType", (), "S64",
                                     data=np.string_(orbit_type))
     d.attrs["description"] = np.string_(
         "Type of orbit file used in processing")


### PR DESCRIPTION
This PR is to take care of the case when a list of orbit file was provided in RTC-S1's runconfig when populating the orbit information into `/metadata/orbit/orbitType` in metadata.
In case of using restituted orbit (RESORB) file, there is a rare chance that a single RESORB file does not cover sentinel-1 frame's sensing start/stop with ~100 minutes of margin at the sensing start. The margin is necessary to ensure at least one ascending node crossing event before sensing start, so that ascending node crossing time (ANX time) can be corrected properly.

In case when the list of orbit file was provided, it extracts the types of each individual orbit file, concatenate them with a separator `;`, and put the string into `/metadata/orbit/orbitType`.