### PR TITLE
Updates on unit test and `environment.yml`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,17 +45,6 @@ jobs:
         with:
           environment-file: ${{ matrix.env-file.file }}
           environment-name: RTC
-
-      # Install the S1-Reader OPERA-ADT project.
-      - name: Install S1-Reader
-        run: |
-          curl -sSL \
-            https://github.com/opera-adt/s1-reader/archive/refs/tags/v0.1.7.tar.gz \
-            -o s1_reader_src.tar.gz \
-          && tar -xvf s1_reader_src.tar.gz \
-          && ln -s s1-reader-0.1.7 s1-reader \
-          && rm s1_reader_src.tar.gz \
-          && python -m pip install ./s1-reader
       
       # Setup the project
       - name: Install Project

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,18 @@ jobs:
         with:
           environment-file: ${{ matrix.env-file.file }}
           environment-name: RTC
-      
+
+      # Install the S1-Reader OPERA-ADT project.
+      - name: Install S1-Reader
+        run: |
+          curl -sSL \
+            https://github.com/opera-adt/s1-reader/archive/refs/tags/v0.2.2.tar.gz \
+            -o s1_reader_src.tar.gz \
+          && tar -xvf s1_reader_src.tar.gz \
+          && ln -s s1-reader-0.2.2 s1-reader \
+          && rm s1_reader_src.tar.gz \
+          && python -m pip install ./s1-reader      
+
       # Setup the project
       - name: Install Project
         run: python -m pip install .

--- a/Docker/environment.yml
+++ b/Docker/environment.yml
@@ -4,10 +4,12 @@ channels:
 dependencies:
   - python>=3.9,<3.10
   - gdal>=3.0
-  - s1reader>=0.2.1
+  - s1reader>=0.2.2
   - numpy>=1.20
   - pybind11>=2.5
   - pyre>=1.11.2
   
   - scipy!=1.10.0
   - isce3>=0.15.0
+  # Workaround for the issue with `libabseil` (09/11/2023)
+  - libabseil=20230125.3


### PR DESCRIPTION
This PR is to update the unit test workflow, as well as `environment.yml`

- Skip installing `s1-reader` from source code in the unit test. It will be installed as conda package
- update the version of `s1-reader` to `0.2.2`
- As a temporary workaround constrain the version of `libabseil` to `20230125.3` because the most recent release of the library (`20230802.0`) has caused the issue like below:

```
ImportError while importing test module '/u/aurora-r0/jeong/opera-adt/RTC_seongsujeong/tests/test_rtc_s1_workflow.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../tools/mambaforge/envs/rtc_s1_sas_final/lib/python3.9/site-packages/osgeo/__init__.py:30: in swig_import_helper
    return importlib.import_module(mname)
../../../tools/mambaforge/envs/rtc_s1_sas_final/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
<frozen importlib._bootstrap>:986: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:666: in _load_unlocked
    ???
<frozen importlib._bootstrap>:565: in module_from_spec
    ???
<frozen importlib._bootstrap_external>:1173: in create_module
    ???
<frozen importlib._bootstrap>:228: in _call_with_frames_removed
    ???
E   ImportError: libabsl_cordz_info.so.2301.0.0: cannot open shared object file: No such file or directory

During handling of the above exception, another exception occurred:
../../../tools/mambaforge/envs/rtc_s1_sas_final/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
test_rtc_s1_workflow.py:6: in <module>
    from osgeo import gdal
../../../tools/mambaforge/envs/rtc_s1_sas_final/lib/python3.9/site-packages/osgeo/__init__.py:35: in <module>
    _gdal = swig_import_helper()
../../../tools/mambaforge/envs/rtc_s1_sas_final/lib/python3.9/site-packages/osgeo/__init__.py:32: in swig_import_helper
    return importlib.import_module('_gdal')
../../../tools/mambaforge/envs/rtc_s1_sas_final/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
E   ModuleNotFoundError: No module named '_gdal'

```