### PR TITLE
Changes after R5

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -2,7 +2,7 @@ FROM oraclelinux:8
 
 LABEL author="OPERA ADT" \
     description="RTC cal/val release R4" \
-    version="1.0.0-final"
+    version="1.0.1-final"
 
 RUN yum -y update &&\
     yum -y install curl &&\

--- a/build_docker_image.sh
+++ b/build_docker_image.sh
@@ -2,7 +2,7 @@
 
 REPO=opera
 IMAGE=rtc
-TAG=final_1.0.0
+TAG=final_1.0.1
 
 echo "IMAGE is $REPO/$IMAGE:$TAG"
 

--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -1199,7 +1199,7 @@ def all_metadata_dict_to_geotiff_metadata_dict(metadata_dict):
         if key is None:
             continue
         if isinstance(value, str):
-            geotiff_metadata_dict[key.upper()] = str(value).upper()
+            geotiff_metadata_dict[key.upper()] = str(value)
             continue
         geotiff_metadata_dict[key.upper()] = value
 

--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -1095,7 +1095,7 @@ def get_metadata_dict(product_id: str,
                       '[pixel_coordinate_convention]'] = \
             ['bounding_box_pixel_coordinate_convention',
              ALL_PRODUCTS,
-             'Upper left corner (ULC)',
+             "Edges/corners",
              'Bounding box pixel coordinate convention']
 
         metadata_dict['identification/burstID'] = \

--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -860,7 +860,7 @@ def get_metadata_dict(product_id: str,
             ['processing_information'
              '_output_backscatter_decibel_conversion_equation',
              ALL_PRODUCTS,
-             'backscatter_dB = 10*log10(backscatter_linear)',
+             '10*log10(backscatter_linear)',
              'Equation to convert provided backscatter to decibel (dB)'],
 
         # 4.4

--- a/src/rtc/version.py
+++ b/src/rtc/version.py
@@ -1,1 +1,1 @@
-VERSION='1.0.0'
+VERSION='1.0.1'


### PR DESCRIPTION
Main update:
- Don't capitalize GeoTIFF metadata values.

Minor updates:
- Update BBOX `pixel_coordinate_convention` from `Upper left corner (ULC)` to `Edges/corners`.
- Update backscatter to dB conversion from `BACKSCATTER_DB = 10*LOG10(BACKSCATTER_LINEAR)` to `10*LOG10(BACKSCATTER_LINEAR)`.