### PR TITLE
Changes for v1.0.2 (WIP)

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -2,7 +2,7 @@ FROM oraclelinux:8
 
 LABEL author="OPERA ADT" \
     description="RTC cal/val release R4" \
-    version="1.0.1-final"
+    version="1.0.2-final"
 
 RUN yum -y update &&\
     yum -y install curl &&\

--- a/build_docker_image.sh
+++ b/build_docker_image.sh
@@ -2,7 +2,7 @@
 
 REPO=opera
 IMAGE=rtc
-TAG=final_1.0.1
+TAG=final_1.0.2
 
 echo "IMAGE is $REPO/$IMAGE:$TAG"
 

--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -430,6 +430,18 @@ def get_metadata_dict(product_id: str,
         cfg_in.groups.product_group.static_layers_data_access
     if not static_layers_data_access:
         static_layers_data_access = '(NOT PROVIDED)'
+    else:
+        # substitute substring "{burst_id}" with the burst ID used for
+        # URL data access, with format updated from "t018_038602_iw2" to
+        # "T018-038602-iw2")
+        burst_id_asf = str(burst_in.burst_id).upper().replace('_', '-')
+        static_layers_data_access = static_layers_data_access.replace(
+            '{burst_id}', f'{burst_id_asf}')
+
+        # update substring "{end_date}"
+        end_date_str = burst_in.sensing_stop.strftime('%Y-%m-%d')
+        static_layers_data_access = static_layers_data_access.replace(
+            '{end_date}', f'{end_date_str}')
 
     # platform ID
     if burst_in.platform_id == 'S1A':

--- a/src/rtc/mosaic_geobursts.py
+++ b/src/rtc/mosaic_geobursts.py
@@ -623,13 +623,13 @@ def mosaic_single_output_file(list_rtc_images, list_nlooks, mosaic_filename,
 
     for i_band in range(num_bands):
         gdal_band = raster_out.GetRasterBand(i_band+1)
-        gdal_band.WriteArray(arr_numerator[i_band])
         gdal_band.SetDescription(description_list[i_band])
         if ctable is not None:
             gdal_band.SetRasterColorTable(ctable)
             gdal_band.SetRasterColorInterpretation(gdal.GCI_PaletteIndex)
         if no_data_value is not None:
             gdal_band.SetNoDataValue(no_data_value)
+        gdal_band.WriteArray(arr_numerator[i_band])
 
     band_ds = None
     reference_raster = None
@@ -710,12 +710,12 @@ def mosaic_multiple_output_files(
 
         # for i_band in range(num_bands):
         band_out = raster_out.GetRasterBand(1)
-        band_out.WriteArray(arr_numerator[i_band])
         if ctable is not None:
             band_out.SetRasterColorTable(ctable)
             band_out.SetRasterColorInterpretation(gdal.GCI_PaletteIndex)
         if no_data_value is not None:
             band_out.SetNoDataValue(no_data_value)
+        band_out.WriteArray(arr_numerator[i_band])
 
     band_ds = None
     reference_raster = None

--- a/src/rtc/rtc_s1_single_job.py
+++ b/src/rtc/rtc_s1_single_job.py
@@ -822,13 +822,13 @@ def set_mask_fill_value_and_ctable(mask_file, reference_file):
     mask_gdal_band = mask_gdal_ds.GetRasterBand(1)
     mask_array = mask_gdal_band.ReadAsArray()
     mask_array[(np.isnan(ref_array)) & (mask_array == 0)] = 255
-    mask_gdal_band.WriteArray(mask_array)
     mask_gdal_band.SetNoDataValue(255)
 
     mask_ctable.SetColorEntry(255, (0, 0, 0, 0))
     mask_gdal_band.SetRasterColorTable(mask_ctable)
     mask_gdal_band.SetRasterColorInterpretation(
         gdal.GCI_PaletteIndex)
+    mask_gdal_band.WriteArray(mask_array)
 
     del mask_gdal_band
     del mask_gdal_ds

--- a/src/rtc/version.py
+++ b/src/rtc/version.py
@@ -1,1 +1,1 @@
-VERSION='1.0.1'
+VERSION='1.0.2'


### PR DESCRIPTION
This PR updates the RTC SAS for v1.0.2. Changes:
- Reorder call to GDAL band WriteArray() to fix issues with GDAL >= 3.8.
- Update setting of the static-layers data access with substrings "{burst_id}" and "{end_date}".
- (TBD)