### PR TITLE
Save the zero-Doppler spacing in meters in the product's metadata

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -37,9 +37,9 @@ SHELL ["conda", "run", "-n", "RTC", "/bin/bash", "-c"]
 WORKDIR /home/rtc_user/OPERA
 
 # installing OPERA s1-reader
-RUN curl -sSL https://github.com/isce-framework/s1-reader/archive/refs/tags/v0.2.2.tar.gz -o s1_reader_src.tar.gz &&\
+RUN curl -sSL https://github.com/isce-framework/s1-reader/archive/refs/tags/v0.2.4.tar.gz -o s1_reader_src.tar.gz &&\
     tar -xvf s1_reader_src.tar.gz &&\
-    ln -s s1-reader-0.2.2 s1-reader &&\
+    ln -s s1-reader-0.2.4 s1-reader &&\
     rm s1_reader_src.tar.gz &&\
     python -m pip install ./s1-reader
 

--- a/Docker/environment.yml
+++ b/Docker/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python>=3.9,<3.10
   - gdal>=3.0
-  - s1reader>=0.2.2
+  - s1reader>=0.2.4
   - numpy>=1.20
   - pybind11>=2.5
   - pyre>=1.11.2

--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -158,7 +158,7 @@ def get_polygon_wkt(burst_in: Sentinel1BurstSlc):
     else:
         geometry_polygon = shapely.geometry.MultiPolygon(burst_in.border)
     if geometry_polygon.is_empty:
-        error_msg = f'empty bouding polygon for burst ID {burst_in.burst_id}'
+        error_msg = f'empty bounding polygon for burst ID {burst_in.burst_id}'
         raise RuntimeError(error_msg)
     if not geometry_polygon.is_valid:
         error_msg = f'invalid bounding polygon for burst ID {burst_in.burst_id}'

--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -154,10 +154,15 @@ def get_polygon_wkt(burst_in: Sentinel1BurstSlc):
     '''
 
     if len(burst_in.border) == 1:
-        geometry_polygon = burst_in.border[0]
+        geometry_polygon = shapely.geometry.Polygon(burst_in.border[0])
     else:
         geometry_polygon = shapely.geometry.MultiPolygon(burst_in.border)
-
+    if geometry_polygon.is_empty:
+        error_msg = f'empty bouding polygon for burst ID {burst_in.burst_id}'
+        raise RuntimeError(error_msg)
+    if not geometry_polygon.is_valid:
+        error_msg = f'invalid bounding polygon for burst ID {burst_in.burst_id}'
+        raise RuntimeError(error_msg)
     return geometry_polygon.wkt
 
 

--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -490,6 +490,13 @@ def get_metadata_dict(product_id: str,
     else:
         mosaic_snap_y = float(mosaic_snap_y)
 
+    # average azimuth pixel spacing
+    try:
+        average_zero_doppler_spacing_in_meters = \
+            burst_in.average_azimuth_pixel_spacing
+    except AttributeError:
+        average_zero_doppler_spacing_in_meters = '(UNSPECIFIED)'
+
     # Geometric accuracy
     estimated_geometric_accuracy_bias_y = \
         cfg_in.groups.processing.geocoding.estimated_geometric_accuracy_bias_y
@@ -745,6 +752,12 @@ def get_metadata_dict(product_id: str,
              ALL_PRODUCTS,
              burst_in.azimuth_time_interval,
              'Time interval in the along-track direction of the source data'],
+        'metadata/sourceData/averageZeroDopplerSpacingInMeters':  # 1.6.7
+            ['source_data_average_zero_doppler_spacing_in_meters',
+             ALL_PRODUCTS,
+             average_zero_doppler_spacing_in_meters,
+             'Average pixel spacing in meters between consecutive lines'
+             ' in the along-track direction of the source data'],
         'metadata/sourceData/slantRangeSpacing':  # 1.6.7
             ['source_data_slant_range_spacing',
              ALL_PRODUCTS,


### PR DESCRIPTION
This PR updates the RTC-S1 SAS to save the zero-Doppler spacing in meters in the products' metadata. It requires the [OPERA S1-Reader](https://github.com/isce-framework/s1-reader) version `0.2.4` that provides the new attribute `average_azimuth_pixel_spacing` parsed from the S1 annotation files field `azimuthPixelSpacing`.