### PR TITLE
Do not delete the output directory

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,4 +1,4 @@
- Docker/DockerfileFROM oraclelinux:8
+FROM oraclelinux:8
 
 LABEL author="OPERA ADT" \
     description="RTC cal/val release R4" \

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,8 +1,8 @@
-FROM oraclelinux:8
+ Docker/DockerfileFROM oraclelinux:8
 
 LABEL author="OPERA ADT" \
     description="RTC cal/val release R4" \
-    version="1.0.2-final"
+    version="1.0.3-final"
 
 RUN yum -y update &&\
     yum -y install curl &&\

--- a/build_docker_image.sh
+++ b/build_docker_image.sh
@@ -2,7 +2,7 @@
 
 REPO=opera
 IMAGE=rtc
-TAG=final_1.0.2
+TAG=final_1.0.3
 
 echo "IMAGE is $REPO/$IMAGE:$TAG"
 

--- a/src/rtc/rtc_s1.py
+++ b/src/rtc/rtc_s1.py
@@ -620,12 +620,6 @@ def run_parallel(cfg: RunConfig, logfile_path, flag_logger_full_format):
                 f'"{burst_runconfig_list[index_child]}" for burst ID '
                 f'"{burst_id}"\n')
 
-        # if output directory is empty, delete it
-        if (os.path.isdir(output_dir) and
-                len(os.listdir(output_dir)) == 0):
-            logger.info(f'Removing output directory: {output_dir}')
-            os.rmdir(output_dir)
-
         raise RuntimeError(msg_failed_child_proc)
 
     lookside = None

--- a/src/rtc/version.py
+++ b/src/rtc/version.py
@@ -1,1 +1,1 @@
-VERSION='1.0.2'
+VERSION='1.0.3'


### PR DESCRIPTION
This PR addresses the issue #86 and updates the RTC-S1 SAS to avoid deleting the output directory in case of an error.