### PR TITLE
update test yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       
       # Set the conda environment up using Mamba and install dependencies
       - name: Setup Environment
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@main
         with:
           environment-file: ${{ matrix.env-file.file }}
           environment-name: RTC


### PR DESCRIPTION
This PR update test yml file. 
mamba-org/provision-with-micromamba action is no longer maintained and was written for an old micromamba CLI that still accepted micromamba shell init … -p <path>.

Refer to the link : https://github.com/mamba-org/provision-with-micromamba#migration-to-setup-micromamba%60