### PR TITLE
Add `LAYER_NAME` and correct overview algorithm for HH and HV GeoTIFFs.

### DIFF
--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -29,6 +29,8 @@ logger = logging.getLogger('rtc_s1')
 
 LAYER_NAME_VV = 'VV'
 LAYER_NAME_VH = 'VH'
+LAYER_NAME_HH = 'HH'
+LAYER_NAME_HV = 'HV'
 LAYER_NAME_LAYOVER_SHADOW_MASK = 'mask'
 LAYER_NAME_RTC_ANF_GAMMA0_TO_BETA0 = 'rtc_anf_gamma0_to_beta0'
 LAYER_NAME_RTC_ANF_GAMMA0_TO_SIGMA0 = 'rtc_anf_gamma0_to_sigma0'
@@ -46,6 +48,8 @@ LAYER_NAME_DEM = 'interpolated_dem'
 layer_hdf5_dict = {
     LAYER_NAME_VV: 'VV',
     LAYER_NAME_VH: 'VH',
+    LAYER_NAME_HH: 'HH',
+    LAYER_NAME_HV: 'HV',
     LAYER_NAME_LAYOVER_SHADOW_MASK: 'mask',
     LAYER_NAME_RTC_ANF_GAMMA0_TO_BETA0:
         'rtcAreaNormalizationFactorGamma0ToBeta0',
@@ -68,6 +72,8 @@ layer_hdf5_dict = {
 layer_names_dict = {
     LAYER_NAME_VV: 'RTC-S1 VV Backscatter',
     LAYER_NAME_VH: 'RTC-S1 VH Backscatter',
+    LAYER_NAME_HH: 'RTC-S1 HH Backscatter',
+    LAYER_NAME_HV: 'RTC-S1 HV Backscatter',
     LAYER_NAME_LAYOVER_SHADOW_MASK: 'Mask Layer',
     LAYER_NAME_RTC_ANF_GAMMA0_TO_BETA0: ('RTC Area Normalization Factor'
                                          ' Gamma0 to Beta0'),
@@ -95,6 +101,10 @@ layer_description_dict = {
     LAYER_NAME_VV: ('Radiometric terrain corrected Sentinel-1 VV backscatter'
                     ' coefficient normalized to gamma0'),
     LAYER_NAME_VH: ('Radiometric terrain corrected Sentinel-1 VH backscatter'
+                    ' coefficient normalized to gamma0'),
+    LAYER_NAME_HH: ('Radiometric terrain corrected Sentinel-1 HH backscatter'
+                    ' coefficient normalized to gamma0'),
+    LAYER_NAME_HV: ('Radiometric terrain corrected Sentinel-1 HV backscatter'
                     ' coefficient normalized to gamma0'),
     LAYER_NAME_LAYOVER_SHADOW_MASK: ('Mask Layer. Values: 0: not'
                                      ' masked; 1: shadow; 2: layover;'


### PR DESCRIPTION
This PR adds the metadata field `LAYER_NAME` to HH and HV GeoTIFFs with values "RTC-S1 HH Backscatter" and "RTC-S1 HV Backscatter", respectively. This field is already added to VV and VH GeoTIFFs, so VV and VH layers are not affected. As a side effect, this change also fixes the resampling algorithm for computing the overviews for the HH and HV layers. This happens because the choice of the resampling algorithm "AVERAGE" and "CUBICSPLINE" depends on the type of data, and the "LAYER_NAME" is used to indicate when a layer contains radar backscatter in which case the "AVERAGE" algorithm should be used. Since the field `LAYER_NAME` was missing from HH and HV layers, the resampling algorithm to generate the overview for these layers was errouneosly set to "CUBICSPLINE"

This PR adds the `LAYER_NAME` metadata field to the HH and HV GeoTIFFs, setting it to "RTC-S1 HH Backscatter" and "RTC-S1 HV Backscatter", accordingly. This field is already included in the VV and VH GeoTIFFs, so those layers are not affected.

As a result of this change, the correct resampling method is now used when creating image overviews for the HH and HV layers. The software chooses between the "AVERAGE" and "CUBICSPLINE" resampling methods based on the type of data. The `LAYER_NAME` field identify radar backscatter data, in which case, the "AVERAGE" algorithm should be used for resampling. Since this field was missing, the software incorrectly used "CUBICSPLINE" for HH and HV layers. Adding `LAYER_NAME` now fixes that.