### PR TITLE
Enable Sentinel-1 EW SLC Processing

### DIFF
--- a/src/rtc/h5_prep.py
+++ b/src/rtc/h5_prep.py
@@ -1619,12 +1619,22 @@ def get_range_azimuth_resolution(burst: Sentinel1BurstSlc):
     -----
     https://sentinels.copernicus.eu/web/sentinel/technical-guides/sentinel-1-sar/
     products-algorithms/level-1/single-look-complex/interferometric-wide-swath
+    Values available in:
+        Sentinel-1 Product Definition, 
+        Document Number: S1-RS-MDA-52-7440
+        S-1 MPC Nomenclature: DI-MPC-PB
+        S-1 MPC Reference: MPC-0239
+    IW SLC -> Table 7-5, EW SLC -> Table 7-8
     '''
-
     resolution_subswath_range_azimuth_dict = {
         'IW1': [2.7, 22.5],
         'IW2': [3.1, 22.7],
-        'IW3': [3.5, 22.6]
+        'IW3': [3.5, 22.6],
+        'EW1': [7.9, 43.7],
+        'EW2': [9.9, 44.3],
+        'EW3': [11.6, 45.2],
+        'EW4': [13.3, 45.6],
+        'EW5': [14.4, 44.0]
     }
 
     slant_range_resolution, azimuth_resolution =\

--- a/src/rtc/runconfig.py
+++ b/src/rtc/runconfig.py
@@ -264,20 +264,26 @@ def runconfig_to_bursts(cfg: SimpleNamespace):
                             'dual-pol': ['HH', 'HV']}
         pols = mode_to_pols[cfg.processing.polarization]
 
-        # zip pol and IW subswath indices together
-        i_subswaths = [1, 2, 3]
+        # get the sensor acquisition mode from the filename
+        sensor_mode = os.path.basename(
+            str(safe_file)).split("_")[1].lower()
+        
+        # set the number of subswaths based on the mode
+        subswaths = {"iw": [1, 2, 3], "ew": [1, 2, 3, 4, 5]}[sensor_mode]
+
+        # zip pol and IW/EW subswath indices together
         pol_subswath_index_pairs = [(pol, i)
-                                    for pol in pols for i in i_subswaths]
+                                    for pol in pols for i in subswaths]
 
         # list of burst ID + polarization tuples
         # used to prevent reference repeats
         id_pols_found = []
 
         # loop over pol and subswath index combinations
-        for pol, i_subswath in pol_subswath_index_pairs:
+        for pol, subswath in pol_subswath_index_pairs:
 
             # loop over burst objs extracted from SAFE zip
-            for burst in load_bursts(safe_file, orbit_file_path, i_subswath,
+            for burst in load_bursts(safe_file, orbit_file_path, subswath,
                                      pol, flag_apply_eap=False):
                 # get burst ID
                 burst_id = str(burst.burst_id)


### PR DESCRIPTION
### Enable Sentinel-1 EW SLC Processing

Adds support for processing Sentinel-1 Extra Wide (EW) mode SLC data through the OPERA RTC pipeline. Like IW mode, EW SLCs contain burst-level information that can be processed using the RTC tool. Below is a sample EW NRB burst product from the file `S1A_EW_SLC__1SDH_20220330T185405_20220330T185511_042554_051380_3E95`

### Burst ID : t132_256983_ew4

<img width="1747" height="1024" alt="image" src="https://github.com/user-attachments/assets/c493e63c-6c00-4149-8d19-03474785fb75" />


### Overview of Changes to RTC Code

A small amount of additional logic is required in the RTC project to detect whether an input Sentinel-1 SLC was acquired in IW or EW mode, and to set the number of sub-swaths accordingly before passing to s1-reader (3 for IW, 5 for EW).

**NOTE These changes add new functionality without altering existing IW processing capabilities, and the RTC changes can therefore be merged independently of the dependent projects**.

### Other Dependencies to enable EW SLC processing

Full EW processing requires the following to be in place:
- s1-reader updated with the changes proposed in https://github.com/isce-framework/s1-reader/pull/153
- If a [burst_database_file](https://github.com/opera-adt/RTC/blob/main/src/rtc/defaults/rtc_s1.yaml#L36) is required, it must be generated using burst_db with the changes implemented in the following PR https://github.com/opera-adt/burst_db/pull/140. A flag can now be specified to generate the equivalent database for EW mode, e.g. `opera-db create --sensor-mode EW`.

The dependencies for RTC will therefore need to be updated with these changes to enable EW processing. 

